### PR TITLE
Fix hasNext On ResultSetIterator For Empty ResultSets

### DIFF
--- a/src/main/java/org/jooq/lambda/SQL.java
+++ b/src/main/java/org/jooq/lambda/SQL.java
@@ -155,13 +155,13 @@ public final class SQL {
         private final Function<ResultSet, T>         rowFunction;
         private final Consumer<? super SQLException> exceptionTranslator;
         private       ResultSet                      rs;
-        private       boolean                        afterFirst;
+        private       boolean                        onOrAfterFirst;
         
         ResultSetIterator(Supplier<? extends ResultSet> supplier, Function<ResultSet, T> rowFunction, Consumer<? super SQLException> exceptionTranslator) {
             this.supplier = supplier;
             this.rowFunction = rowFunction;
             this.exceptionTranslator = exceptionTranslator;
-            this.afterFirst = false;
+            this.onOrAfterFirst = false;
         }
 
         private ResultSet rs() {
@@ -171,7 +171,7 @@ public final class SQL {
         @Override
         public boolean hasNext() {
             try {
-                return ( afterFirst && !rs().isLast() ) || rs().isBeforeFirst();
+                return ( onOrAfterFirst && !rs().isLast() ) || rs().isBeforeFirst();
             }
             catch (SQLException e) {
                 exceptionTranslator.accept(e);
@@ -183,7 +183,7 @@ public final class SQL {
         public T next() {
             try {
                 if (rs().next()) {
-                	afterFirst = true;
+                    onOrAfterFirst = true;
                     return rowFunction.apply(rs());
                 }
                 else {


### PR DESCRIPTION
!isLast will return true for empty result sets as well which will lead to next() being called and throwing an IllegalStateException... Added in a check against isBeforeFirst which will return false for empty result sets.
