### PR TITLE
Added javadocs for Seq methods regarding parallel and unordered Streams

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -5235,16 +5235,34 @@ public interface Seq<T> extends Stream<T>, Iterable<T> {
     // These methods have no effect
     // ----------------------------
 
+    /**
+     * Returns this stream. All Seq streams are sequential, hence the name.
+     *
+     * @return this stream unmodified
+     */
     @Override
     default Seq<T> sequential() {
         return this;
     }
 
+    /**
+     * Seq streams are always sequential and, as such, doesn't support
+     * parallelization.
+     *
+     * @return this sequential stream unmodified
+     * @see <a href="https://github.com/jOOQ/jOOL/issues/130">jOOL Issue #130</a>
+     */
     @Override
     default Seq<T> parallel() {
         return this;
     }
 
+    /**
+     * Returns this stream. All Seq streams are ordered so this method has
+     * no effect.
+     *
+     * @return this stream unmodified
+     */
     @Override
     default Seq<T> unordered() {
         return this;

--- a/src/main/java/org/jooq/lambda/SeqImpl.java
+++ b/src/main/java/org/jooq/lambda/SeqImpl.java
@@ -226,6 +226,13 @@ class SeqImpl<T> implements Seq<T> {
         return stream().spliterator();
     }
 
+    /**
+     * Always returns false. Seq streams are always sequential and, as such,
+     * doesn't support parallelization.
+     *
+     * @return false
+     * @see <a href="https://github.com/jOOQ/jOOL/issues/130">jOOL Issue #130</a>
+     */
     @Override
     public boolean isParallel() {
         return false;


### PR DESCRIPTION
Fixes #130.
As discussed in the issue we're hinting on the javadocs that some Stream
methods just are no-ops on a sequential and ordered stream.