### PR TITLE
Add Seq#take & Seq#drop aliases (Implementation for #170)

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -5606,6 +5606,24 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * Alias for limit
+     *
+     * @see Seq#limit(long)
+     */
+    default Seq<T> take(long maxSize) {
+        return limit(maxSize);
+    }
+
+    /**
+     * Alias for skip
+     *
+     * @see Seq#skip(long)
+     */
+    default Seq<T> drop(long n) {
+        return skip(n);
+    }
+
+    /**
      * Returns a stream limited to all elements for which a predicate evaluates to <code>true</code>.
      * <p>
      * <code><pre>

--- a/src/test/java/org/jooq/lambda/SeqTest.java
+++ b/src/test/java/org/jooq/lambda/SeqTest.java
@@ -2341,4 +2341,14 @@ public class SeqTest {
         test.accept((s1, s2, s3, s4) -> Seq.crossJoin(s1, s2, s3, s4));
         test.accept((s1, s2, s3, s4) -> Seq.zip(s1, s2, s3, s4));
     }
+
+    @Test
+    public void testTakeBehavesAsLimit() {
+        assertTrue(Seq.range(1, 10).take(3).toList().equals(Seq.range(1, 10).limit(3).toList()));
+    }
+
+    @Test
+    public void testDropBehavesAsSkip() {
+        assertTrue(Seq.range(1, 10).drop(3).toList().equals(Seq.range(1, 10).skip(3).toList()));
+    }
 }


### PR DESCRIPTION
`take` is an alias for `Seq#limit`
`drop` is an alias for `Seq#skip`