### PR TITLE
Wrap IOException with UncheckedIOException in Unchecked

### DIFF
--- a/src/main/java/org/jooq/lambda/Unchecked.java
+++ b/src/main/java/org/jooq/lambda/Unchecked.java
@@ -20,6 +20,8 @@ import org.jooq.lambda.fi.util.function.*;
 import org.jooq.lambda.fi.lang.CheckedRunnable;
 import org.jooq.lambda.fi.util.CheckedComparator;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Comparator;
 import java.util.function.*;
 
@@ -46,6 +48,9 @@ public final class Unchecked {
 
         if (t instanceof RuntimeException)
             throw (RuntimeException) t;
+
+        if (t instanceof IOException)
+            throw new UncheckedIOException((IOException) t);
         
         // [#230] Clients will not expect needing to handle this.
         if (t instanceof InterruptedException)


### PR DESCRIPTION
JDK8 comes with [this gem](https://docs.oracle.com/javase/8/docs/api/java/io/UncheckedIOException.html), so it seems natural that `Unckecked` should wrap most hated Java checked exception with new unckecked counterpart. 