### PR TITLE
Blocking#runnable() was not executing the runnable given by argument.

### DIFF
--- a/src/main/java/org/jooq/lambda/Blocking.java
+++ b/src/main/java/org/jooq/lambda/Blocking.java
@@ -71,7 +71,7 @@ import java.util.function.UnaryOperator;
 public final class Blocking {
 
     public static Runnable runnable(Runnable runnable) {
-        return () -> supplier(() -> { runnable.run(); return null; });
+        return () -> supplier(() -> { runnable.run(); return null; }).get();
     }
     
     public static <T, U> BiConsumer<T, U> biConsumer(BiConsumer<? super T, ? super U> biConsumer) {

--- a/src/test/java/org/jooq/lambda/BlockingTest.java
+++ b/src/test/java/org/jooq/lambda/BlockingTest.java
@@ -1,0 +1,31 @@
+package org.jooq.lambda;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class BlockingTest {
+
+    private static ForkJoinPool pool = new ForkJoinPool(1);
+
+    /**
+     * Test that {@link Blocking#runnable(java.lang.Runnable) } executes the given runnable.
+     */
+    @Test
+    public void testRunnable_run() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+
+        Runnable runnable = Blocking.runnable(() -> executed.set(true));
+
+        CompletableFuture.runAsync(runnable, pool)
+                .join();
+        Assert.assertTrue("The given runnable has not been executed", executed.get());
+    }
+
+
+}


### PR DESCRIPTION
The previous implementation of Blocking#runnable(Runnable) created a
blocking supplier, but it did not call Supplier#get(), so the runnable
given by argument was never executed.