### PR TITLE
Share IntelliJ's codeStyleSettings.xml and inspectionProfiles/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-.idea
+/.idea/*
+!/.idea/inspectionProfiles/
+!/.idea/codeStyleSettings.xml
 target
 *.iml


### PR DESCRIPTION
IntelliJ gave me a hard time trying to reformat the `Seq` interface using the default formatting rules (for example, it tried to optimize the imports and hanged for nearly a minute).

Would you mind sharing your `codeStyleSettings.xml` and, optionally, `inspectionProfiles` so that it's easier to provide potential future pull requests?