### PR TITLE
Use binarySearch in rank aggs

### DIFF
--- a/src/main/java/org/jooq/lambda/Agg.java
+++ b/src/main/java/org/jooq/lambda/Agg.java
@@ -651,7 +651,7 @@ public class Agg {
         );
     }
 
-    private static <U> int binarySearchRank(ArrayList<U> l, U value, Comparator<? super U> comparator) {
+    private static <U> int binarySearchRank(List<? extends U> l, U value, Comparator<? super U> comparator) {
         int index = Collections.binarySearch(l, value, comparator);
         if (index < 0)
             index = -index - 1;

--- a/src/main/java/org/jooq/lambda/Agg.java
+++ b/src/main/java/org/jooq/lambda/Agg.java
@@ -644,13 +644,14 @@ public class Agg {
                 if (size == 0)
                     return Optional.empty();
 
-                // TODO: Find a faster implementation using binarySearch
                 l.sort(comparator);
-                for (int i = 0; i < size; i++)
-                    if (comparator.compare(value, l.get(i)) <= 0)
-                        return Optional.of((long) i);
-
-                return Optional.of((long) size);
+                int index = Collections.binarySearch(l, value, comparator);
+                if (index < 0)
+                    index = -index - 1;
+                else
+                    while (index > 0 && l.get(index) == l.get(index - 1))
+                        --index;
+                return Optional.of((long) index);
             }
         );
     }
@@ -693,14 +694,7 @@ public class Agg {
                 if (size == 0)
                     return Optional.empty();
 
-                // TODO: Find a faster implementation using binarySearch
-                int i = -1;
-                Iterator<U> it = l.iterator();
-                while (it.hasNext() && i++ < l.size())
-                    if (comparator.compare(value, it.next()) <= 0)
-                        return Optional.of((long) i);
-
-                return Optional.of((long) size);
+                return Optional.of((long) l.headSet(value).size());
             }
         );
     }
@@ -743,13 +737,14 @@ public class Agg {
                 if (size == 0)
                     return Optional.empty();
 
-                // TODO: Find a faster implementation using binarySearch
                 l.sort(comparator);
-                for (int i = 0; i < size; i++)
-                    if (comparator.compare(value, l.get(i)) <= 0)
-                        return Optional.of((double) i / (double) size);
-
-                return Optional.of(1.0);
+                int index = Collections.binarySearch(l, value, comparator);
+                if (index < 0)
+                    index = -index - 1;
+                else
+                    while (index > 0 && l.get(index) == l.get(index - 1))
+                        --index;
+                return Optional.of((double) index / (double) size);
             }
         );
     }

--- a/src/main/java/org/jooq/lambda/Agg.java
+++ b/src/main/java/org/jooq/lambda/Agg.java
@@ -645,15 +645,20 @@ public class Agg {
                     return Optional.empty();
 
                 l.sort(comparator);
-                int index = Collections.binarySearch(l, value, comparator);
-                if (index < 0)
-                    index = -index - 1;
-                else
-                    while (index > 0 && l.get(index) == l.get(index - 1))
-                        --index;
+                int index = binarySearchRank(l, value, comparator);
                 return Optional.of((long) index);
             }
         );
+    }
+
+    private static <U> int binarySearchRank(ArrayList<U> l, U value, Comparator<? super U> comparator) {
+        int index = Collections.binarySearch(l, value, comparator);
+        if (index < 0)
+            index = -index - 1;
+        else
+            while (index > 0 && l.get(index) == l.get(index - 1))
+                --index;
+        return index;
     }
 
     /**
@@ -738,12 +743,7 @@ public class Agg {
                     return Optional.empty();
 
                 l.sort(comparator);
-                int index = Collections.binarySearch(l, value, comparator);
-                if (index < 0)
-                    index = -index - 1;
-                else
-                    while (index > 0 && l.get(index) == l.get(index - 1))
-                        --index;
+                int index = binarySearchRank(l, value, comparator);
                 return Optional.of((double) index / (double) size);
             }
         );


### PR DESCRIPTION
I removed couple TODOs in `rankBy`, `denseRankBy` and `percentRankBy` aggs which now use more optimized versions. First two now use `Collections.binarySearch` with a simple while to determine first occurrence (position) in list, last one uses dedicated method in `TreeSet` since it was already used.