### PR TITLE
Unchecked.objIntConsumer doesn't throw IllegalStateException as it should

### DIFF
--- a/src/main/java/org/jooq/lambda/Unchecked.java
+++ b/src/main/java/org/jooq/lambda/Unchecked.java
@@ -67,7 +67,7 @@ public final class Unchecked {
     /**
      * "sneaky-throw" a checked exception or throwable.
      */
-    public static final void throwChecked(Throwable t) {
+    public static void throwChecked(Throwable t) {
         SeqUtils.sneakyThrow(t);
     }
 

--- a/src/main/java/org/jooq/lambda/Unchecked.java
+++ b/src/main/java/org/jooq/lambda/Unchecked.java
@@ -211,6 +211,8 @@ public final class Unchecked {
             }
             catch (Throwable e) {
                 handler.accept(e);
+
+                throw new IllegalStateException("Exception handler must throw a RuntimeException", e);
             }
         };
     }

--- a/src/main/java/org/jooq/lambda/Unchecked.java
+++ b/src/main/java/org/jooq/lambda/Unchecked.java
@@ -62,9 +62,7 @@ public final class Unchecked {
     /**
      * A {@link Consumer} that rethrows all exceptions, including checked exceptions.
      */
-    public static final Consumer<Throwable> RETHROW_ALL = t -> {
-        SeqUtils.sneakyThrow(t);
-    };
+    public static final Consumer<Throwable> RETHROW_ALL = SeqUtils::sneakyThrow;
     
     /**
      * "sneaky-throw" a checked exception or throwable.


### PR DESCRIPTION
I added missing `IllegalStateException` in `Unchecked.objIntConsumer` (I guess it wasn't auto-generated). It wasn't caught by tests - unfortunately they use ISE as expected exception, so in order to add test for this case refactoring is needed. Did you consider using parametrized tests to cover all variants of methods (not only in `Unchecked`)?

Two other minor changes:
 - removed redundant `final`,
 - used method reference - I wonder if you fancy those, because I don't see many method references in the code.