### PR TITLE
Add Seq#zipWithIndex(BiFunction)

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -1049,7 +1049,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
      * Seq.of(1, 2, 3).zip(Seq.of("a", "b", "c"), (i, s) -> i + ":" + s)
      * </pre></code>
      *
-     * @see #zip(Seq, BiFunction)
+     * @see #zip(Seq, Seq, BiFunction)
      */
     default <U, R> Seq<R> zip(Seq<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
         return zip(this, other, zipper);
@@ -6598,7 +6598,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
 
         return SeqUtils.transform(stream, (delegate, action) ->
             delegate.tryAdvance(t ->
-                action.accept(tuple(t, index[0] = index[0] + 1))
+                action.accept(tuple(t, ++index[0]))
             )
         );
     }

--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -3024,6 +3024,20 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * Zip a stream with indexes into one using a {@link BiFunction} to produce resulting values.
+     * <p>
+     * <code><pre>
+     * // ("0:a", "1:b", "2:c")
+     * Seq.of("a", "b", "c").zipWithIndex((s, i) -> i + ":" + s))
+     * </pre></code>
+     *
+     * @see #zipWithIndex(Seq, BiFunction)
+     */
+    default <R> Seq<R> zipWithIndex(BiFunction<? super T, ? super Long, ? extends R> zipper) {
+        return zipWithIndex(this, zipper);
+    }
+
+    /**
      * Fold a Stream to the left.
      * <p>
      * <code><pre>
@@ -6585,6 +6599,48 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
         return SeqUtils.transform(stream, (delegate, action) ->
             delegate.tryAdvance(t ->
                 action.accept(tuple(t, index[0] = index[0] + 1))
+            )
+        );
+    }
+
+    /**
+     * Zip a stream with indexes into one using a {@link BiFunction} to produce resulting values.
+     * <p>
+     * <code><pre>
+     * // ("0:a", "1:b", "2:c")
+     * Seq.of("a", "b", "c").zipWithIndex((s, i) -> i + ":" + s))
+     * </pre></code>
+     */
+    static <T, R> Seq<R> zipWithIndex(Stream<? extends T> stream, BiFunction<? super T, ? super Long, ? extends R> zipper) {
+        return zipWithIndex(seq(stream), zipper);
+    }
+
+    /**
+     * Zip a stream with indexes into one using a {@link BiFunction} to produce resulting values.
+     * <p>
+     * <code><pre>
+     * // ("0:a", "1:b", "2:c")
+     * Seq.of("a", "b", "c").zipWithIndex((s, i) -> i + ":" + s))
+     * </pre></code>
+     */
+    static <T, R> Seq<R> zipWithIndex(Iterable<? extends T> iterable, BiFunction<? super T, ? super Long, ? extends R> zipper) {
+        return zipWithIndex(seq(iterable), zipper);
+    }
+
+    /**
+     * Zip a stream with indexes into one using a {@link BiFunction} to produce resulting values.
+     * <p>
+     * <code><pre>
+     * // ("0:a", "1:b", "2:c")
+     * Seq.of("a", "b", "c").zipWithIndex((s, i) -> i + ":" + s))
+     * </pre></code>
+     */
+    static <T, R> Seq<R> zipWithIndex(Seq<? extends T> stream, BiFunction<? super T, ? super Long, ? extends R> zipper) {
+        long[] index = { -1L };
+
+        return SeqUtils.transform(stream, (delegate, action) ->
+            delegate.tryAdvance(t ->
+                action.accept(zipper.apply(t, ++index[0]))
             )
         );
     }

--- a/src/test/java/org/jooq/lambda/SeqTest.java
+++ b/src/test/java/org/jooq/lambda/SeqTest.java
@@ -431,6 +431,14 @@ public class SeqTest {
     }
 
     @Test
+    public void testZipWithIndexBiFunction() {
+        assertEquals(asList(), Seq.of().zipWithIndex((s, i) -> s + ":" + i).toList());
+        assertEquals(asList("a:0"), Seq.of("a").zipWithIndex((s, i) -> s + ":" + i).toList());
+        assertEquals(asList("a:0", "b:1"), Seq.of("a", "b").zipWithIndex((s, i) -> s + ":" + i).toList());
+        assertEquals(asList("a:0", "b:1", "c:2"), Seq.of("a", "b", "c").zipWithIndex((s, i) -> s + ":" + i).toList());
+    }
+
+    @Test
     public void testDuplicate() {
         Supplier<Tuple2<Seq<Integer>, Seq<Integer>>> reset = () -> Seq.of(1, 2, 3).duplicate();
         Tuple2<Seq<Integer>, Seq<Integer>> duplicate;
@@ -2515,6 +2523,29 @@ public class SeqTest {
         assertEquals(
             asList(tuple("c", 0L), tuple("b", 2L), tuple("a", 1L)),
             Seq.of("c", "a", "b").zipWithIndex().sorted(reverseOrder()).toList()
+        );
+    }
+
+    @Test
+    public void testSortedWithZipWithIndexBiFunction() {
+        assertEquals(
+            asList("a:0", "b:1", "c:2"),
+            Seq.of("c", "a", "b").sorted().zipWithIndex((s, i) -> s + ":" + i).toList()
+        );
+
+        assertEquals(
+            asList("c:0", "b:1", "a:2"),
+            Seq.of("c", "a", "b").sorted(reverseOrder()).zipWithIndex((s, i) -> s + ":" + i).toList()
+        );
+
+        assertEquals(
+            asList("a:1", "b:2", "c:0"),
+            Seq.of("c", "a", "b").zipWithIndex((s, i) -> s + ":" + i).sorted().toList()
+        );
+
+        assertEquals(
+            asList("c:0", "b:2", "a:1"),
+            Seq.of("c", "a", "b").zipWithIndex((s, i) -> s + ":" + i).sorted(reverseOrder()).toList()
         );
     }
     


### PR DESCRIPTION
I wanted to use `Seq#zipWithIndex(BiFunction)`, but unfortunately it wasn't available, so here's implementation. Instead writing:

    Seq.of("a", "b", "c")
            .zipWithIndex()
            .map(t -> t.map((s, i) -> i + ":" + s))
            .forEach(System.out::println);

one can write:

    Seq.of("a", "b", "c")
            .zipWithIndex((s, i) -> i + ":" + s))
            .forEach(System.out::println);

(and no `Tuple2` object is created.)