### PR TITLE
Add Agg#first() and Agg#last() collectors

### DIFF
--- a/src/main/java/org/jooq/lambda/Agg.java
+++ b/src/main/java/org/jooq/lambda/Agg.java
@@ -57,6 +57,40 @@ public class Agg {
     }
 
     /**
+     * Get a {@link Collector} that calculates the <code>FIRST</code> function.
+     *
+     * @throws NullPointerException if first element is {@code null}
+     */
+    public static <T> Collector<T, ?, Optional<T>> first() {
+        final Object empty = new Object();
+        return Collector.of(
+                () -> new Object[] { empty },
+                (a, t) -> {
+                    if (a[0] == empty) {
+                        a[0] = t;
+                    }
+                },
+                (a1, a2) -> a1,
+                a -> a[0] == empty ? Optional.empty() : Optional.of((T) a[0])
+        );
+    }
+
+    /**
+     * Get a {@link Collector} that calculates the <code>LAST</code> function.
+     *
+     * @throws NullPointerException if last element is {@code null}
+     */
+    public static <T> Collector<T, ?, Optional<T>> last() {
+        final Object empty = new Object();
+        return Collector.of(
+                () -> new Object[] { empty },
+                (a, t) -> a[0] = t,
+                (a1, a2) -> a2,
+                a -> a[0] == empty ? Optional.empty() : Optional.of((T) a[0])
+        );
+    }
+
+    /**
      * Get a {@link Collector} that calculates the <code>COUNT(*)</code>
      * function.
      */

--- a/src/main/java/org/jooq/lambda/Agg.java
+++ b/src/main/java/org/jooq/lambda/Agg.java
@@ -58,36 +58,16 @@ public class Agg {
 
     /**
      * Get a {@link Collector} that calculates the <code>FIRST</code> function.
-     *
-     * @throws NullPointerException if first element is {@code null}
      */
     public static <T> Collector<T, ?, Optional<T>> first() {
-        final Object empty = new Object();
-        return Collector.of(
-                () -> new Object[] { empty },
-                (a, t) -> {
-                    if (a[0] == empty) {
-                        a[0] = t;
-                    }
-                },
-                (a1, a2) -> a1,
-                a -> a[0] == empty ? Optional.empty() : Optional.of((T) a[0])
-        );
+        return Collectors.reducing((v1, v2) -> v1);
     }
 
     /**
      * Get a {@link Collector} that calculates the <code>LAST</code> function.
-     *
-     * @throws NullPointerException if last element is {@code null}
      */
     public static <T> Collector<T, ?, Optional<T>> last() {
-        final Object empty = new Object();
-        return Collector.of(
-                () -> new Object[] { empty },
-                (a, t) -> a[0] = t,
-                (a1, a2) -> a2,
-                a -> a[0] == empty ? Optional.empty() : Optional.of((T) a[0])
-        );
+        return Collectors.reducing((v1, v2) -> v2);
     }
 
     /**

--- a/src/test/java/org/jooq/lambda/CollectorTests.java
+++ b/src/test/java/org/jooq/lambda/CollectorTests.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import static org.jooq.lambda.Agg.*;
 import static org.jooq.lambda.tuple.Tuple.tuple;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Lukas Eder
@@ -937,5 +938,35 @@ public class CollectorTests {
         assertEquals(1L, (long) Seq.of(1, 2).collect(Agg.filter(t -> t % 2 == 0, Agg.count())));
         assertEquals(1L, (long) Seq.of(1, 2, 3).collect(Agg.filter(t -> t % 2 == 0, Agg.count())));
         assertEquals(2L, (long) Seq.of(1, 2, 3, 4).collect(Agg.filter(t -> t % 2 == 0, Agg.count())));
+    }
+
+    @Test
+    public void testFirst() {
+        assertEquals(Optional.empty(), Seq.<Integer>of().collect(Agg.first()));
+        assertEquals(Optional.of(1), Seq.of(1).collect(Agg.first()));
+        assertEquals(Optional.of(2), Seq.of(2, 3).collect(Agg.first()));
+        assertEquals(Optional.of(4), Seq.of(4, null).collect(Agg.first()));
+        try {
+            Seq.of(null, 5, 6).collect(Agg.first());
+            fail();
+        }
+        catch (Exception e) {
+            assertEquals(NullPointerException.class, e.getClass());
+        }
+    }
+
+    @Test
+    public void testLast() {
+        assertEquals(Optional.empty(), Seq.<Integer>of().collect(Agg.last()));
+        assertEquals(Optional.of(1), Seq.of(1).collect(Agg.last()));
+        assertEquals(Optional.of(3), Seq.of(2, 3).collect(Agg.last()));
+        assertEquals(Optional.of(4), Seq.of(null, 4).collect(Agg.last()));
+        try {
+            Seq.of(5, 6, null).collect(Agg.last());
+            fail();
+        }
+        catch (Exception e) {
+            assertEquals(NullPointerException.class, e.getClass());
+        }
     }
 }

--- a/src/test/java/org/jooq/lambda/CollectorTests.java
+++ b/src/test/java/org/jooq/lambda/CollectorTests.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import static org.jooq.lambda.Agg.*;
 import static org.jooq.lambda.tuple.Tuple.tuple;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * @author Lukas Eder
@@ -946,13 +945,7 @@ public class CollectorTests {
         assertEquals(Optional.of(1), Seq.of(1).collect(Agg.first()));
         assertEquals(Optional.of(2), Seq.of(2, 3).collect(Agg.first()));
         assertEquals(Optional.of(4), Seq.of(4, null).collect(Agg.first()));
-        try {
-            Seq.of(null, 5, 6).collect(Agg.first());
-            fail();
-        }
-        catch (Exception e) {
-            assertEquals(NullPointerException.class, e.getClass());
-        }
+        assertEquals(Optional.empty(), Seq.of(null, 5, 6).collect(Agg.first()));
     }
 
     @Test
@@ -961,12 +954,6 @@ public class CollectorTests {
         assertEquals(Optional.of(1), Seq.of(1).collect(Agg.last()));
         assertEquals(Optional.of(3), Seq.of(2, 3).collect(Agg.last()));
         assertEquals(Optional.of(4), Seq.of(null, 4).collect(Agg.last()));
-        try {
-            Seq.of(5, 6, null).collect(Agg.last());
-            fail();
-        }
-        catch (Exception e) {
-            assertEquals(NullPointerException.class, e.getClass());
-        }
+        assertEquals(Optional.empty(), Seq.of(5, 6, null).collect(Agg.last()));
     }
 }


### PR DESCRIPTION
I implemented `first()` and `last()` collectors, which seems like reasonable feature with `Tuple.collectors` (I had use case where I needed `first()`). [`StreamEx` has those collectors](https://github.com/amaembo/streamex/blob/streamex-0.6.3/src/main/java/one/util/streamex/MoreCollectors.java#L511-L549), but there are two differences with my implementation:

1. StreamEx's `MoreCollectors#first()` can be short circuiting - in jOOL I don't see a purpose for that.
2. Both `first()` and `last()` throw NPE when first / last element is `null` - this is to distinguish empty stream from null element, and also follows [`Stream.findFirst()`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#findFirst--) convention.