### PR TITLE
Add onOptionalThrow for throwing Exceptions via lambda return.

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -440,6 +440,19 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * Produce this stream, or an alternative stream from the
+     * <code>supplier</code>, in case this stream is empty.
+     */
+    default <X extends Throwable> Seq<T> onOptionalThrow(Function<? super T, Optional<? extends X>> function) {
+        return peek(e -> {
+            Optional<? extends X> opt = function.apply(e);
+            if (opt.isPresent()) {
+                sneakyThrow(opt.get());
+            }
+        });
+    }
+
+    /**
      * Concatenate two streams.
      * <p>
      * <code><pre>

--- a/src/test/java/org/jooq/lambda/SeqTest.java
+++ b/src/test/java/org/jooq/lambda/SeqTest.java
@@ -977,7 +977,7 @@ public class SeqTest {
         assertEquals(asList(1), Seq.of().onEmpty(1).toList());
         assertEquals(asList(1), Seq.of().onEmptyGet(() -> 1).toList());
         assertThrows(X.class, () -> Seq.of().onEmptyThrow(() -> new X()).toList());
-
+        
         assertEquals(asList(2), Seq.of(2).onEmpty(1).toList());
         assertEquals(asList(2), Seq.of(2).onEmptyGet(() -> 1).toList());
         assertEquals(asList(2), Seq.of(2).onEmptyThrow(() -> new X()).toList());
@@ -985,6 +985,23 @@ public class SeqTest {
         assertEquals(asList(2, 3), Seq.of(2, 3).onEmpty(1).toList());
         assertEquals(asList(2, 3), Seq.of(2, 3).onEmptyGet(() -> 1).toList());
         assertEquals(asList(2, 3), Seq.of(2, 3).onEmptyThrow(() -> new X()).toList());
+    }
+
+    @Test
+    public void testOnOptionalThrow() throws X {
+        assertThrows(X.class, () -> Seq.of(1, 2, 3).onOptionalThrow(t -> {
+            if (t > 2) {
+                return Optional.of(new X());
+            }
+            return Optional.empty();
+        }).toList());
+
+        Seq.of(1, 2, 3).onOptionalThrow(t -> {
+            if (t > 3) {
+                return Optional.of(new X());
+            }
+            return Optional.empty();
+        }).toList();
     }
 
     @SuppressWarnings("serial")


### PR DESCRIPTION
Enables throwing of Exception without conversion into RuntimeException and try/catch-block. Like this

```java
Seq.of(1, 2, 3).onOptionalThrow(t -> {
     if (t > 3) {
        return Optional.of(new Exception());
    }
    return Optional.empty();
}).toList();
```
Your thoughts?