### PR TITLE
Add Seq.onThrowable() and Seq.onThrowableAs()

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -440,6 +440,20 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * If a throwable occurs, call the <code>throwableHandler</code> on it before rethrowing.
+     */
+    default Seq<T> onThrowable(Consumer<? super Throwable> throwableHandler) {
+        return SeqUtils.transform(this, (delegate, action) -> {
+            try {
+                return delegate.tryAdvance(action);
+            } catch (Throwable throwable) {
+                throwableHandler.accept(throwable);
+                throw throwable;
+            }
+        });
+    }
+
+    /**
      * Concatenate two streams.
      * <p>
      * <code><pre>

--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -454,6 +454,13 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * If a throwable occurs, wrap it in a throwable from the <code>throwableWrapper</code>.
+     */
+    default Seq<T> onThrowableAs(Function<? super Throwable, ? extends Throwable> throwableWrapper) {
+        return onThrowable(throwable -> SeqUtils.sneakyThrow(throwableWrapper.apply(throwable)));
+    }
+
+    /**
      * Concatenate two streams.
      * <p>
      * <code><pre>


### PR DESCRIPTION
I provide two `Seq` methods for consideration:
- `onThrowable(Consumer<? super Throwable> throwableHandler)`
- `onThrowableAs(Function<? super Throwable, ? extends Throwable> throwableWrapper)`

The naming and implementation is subject to improvements.

Rationale:
- I have a method that returns a `Seq` which may then be consumed anywhere else
- the consumption of the `Seq` might throw some recoverable exceptions
- I needed to wrap these exceptions (that might be thrown deep down in the call stack) with a "parent" exception (that can be created only higher up the call stack)

PS. I haven't provided the unit tests.