### PR TITLE
Add Seq.lazy() and Seq.onEmptySupply()

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -390,7 +390,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
-     * Produce this stream, or an alternative stream from the
+     * Produce this stream, or an alternative stream with the
      * <code>value</code>, in case this stream is empty.
      */
     default Seq<T> onEmpty(T value) {
@@ -398,7 +398,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
-     * Produce this stream, or an alternative stream from the
+     * Produce this stream, or an alternative stream with a value from the
      * <code>supplier</code>, in case this stream is empty.
      */
     default Seq<T> onEmptyGet(Supplier<? extends T> supplier) {
@@ -419,7 +419,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
-     * Produce this stream, or an alternative stream from the
+     * Produce this stream, or throw a throwable from the
      * <code>supplier</code>, in case this stream is empty.
      */
     default <X extends Throwable> Seq<T> onEmptyThrow(Supplier<? extends X> supplier) {

--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -4621,7 +4621,14 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     static <T> Seq<T> generate(Supplier<? extends T> s) {
         return seq(Stream.generate(s));
     }
-    
+
+    /**
+     * Lazily produce a <code>Seq</code>.
+     */
+    static <T> Seq<T> lazy(Supplier<? extends Seq<T>> s) {
+        return of(s).flatMap(Supplier::get);
+    }
+
     /**
      * Wrap an array slice into a <code>Seq</code>.
      * 

--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -419,6 +419,17 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * Produce this stream, or an alternative stream from the
+     * <code>supplier</code>, in case this stream is empty.
+     */
+    default Seq<T> onEmptySupply(Supplier<? extends Seq<T>> supplier) {
+        return lazy(() -> {
+            Iterator<T> it = seq.iterator();
+            return it.hasNext() ? seq(it) : supplier.get();
+        });
+    }
+
+    /**
      * Produce this stream, or throw a throwable from the
      * <code>supplier</code>, in case this stream is empty.
      */


### PR DESCRIPTION
Sorry that there are several things at once here but I didn't feel like creating so many PRs (so just pick whatever you like).

Three commits:
1. Some documentation improvements for `Seq.onEmpty*` methods
2. `static Seq.lazy(Supplier<? extends Seq<T>>)` method that returns a lazy `Seq` from the given supplier
(useful to return single-valued sequences as lazy ones, e.g. `Seq.lazy(() -> Seq.of(computeValue()))`)
3. `Seq.onEmptySupply(Supplier<? extends Seq<T>>)` which allows to return an entire `Seq` if the original `Seq` is empty (in contrary to `onEmptyGet` which allows to return only a single-valued `Seq`)
(the `Iterator`-based implementation may be non-optimal but I'm not sure how to do it better)