### PR TITLE
Add Seq.seq(Supplier<? extends T>)

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -4621,7 +4621,14 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     static <T> Seq<T> generate(Supplier<? extends T> s) {
         return seq(Stream.generate(s));
     }
-    
+
+    /**
+     * Lazily produce a <code>Seq</code>.
+     */
+    static <T> Seq<T> lazy(Supplier<? extends Stream<T>> s) {
+        return seq(Stream.of(s).flatMap(Supplier::get));
+    }
+
     /**
      * Wrap an array slice into a <code>Seq</code>.
      * 


### PR DESCRIPTION
`Seq.lazy(Supplier<? extends Stream<T>>)` would take a `Stream` supplier and turn it (lazily) into a `Seq`.

If we wanted to support other types (e.g. `IntStream`, `Iterable<T>`, `Optional<T>`, `T`) we'd have to use different names for each method because of `Supplier`'s type erasure, e.g. `lazySeq`, `lazyIntSeq`, `lazyIterable`, `lazyOptional`, `lazyValue` (they would generally correspond to what can be non-lazily obtained by `Seq.of` and `Seq.seq`).

For me, however, simple `Seq.lazy()` would be quite enough because it's just a matter of calling `Seq.of` or `Seq.seq` inside the lazy `Supplier` body.