### PR TITLE
Added SeqBuffer<T> class as a replacement for some of Seq.toList() calls

### DIFF
--- a/src/main/java/org/jooq/lambda/SeqBuffer.java
+++ b/src/main/java/org/jooq/lambda/SeqBuffer.java
@@ -1,0 +1,203 @@
+package org.jooq.lambda;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * Lazily consumes given <code>Spliterator</code> through <code>Seq</code>s provided by method <code>seq()</code>.
+ * This method may be called multiple times, and the returned <code>Seq</code>s may be consumed interchangeably.
+ *
+ * Instances of this class ARE thread-safe.
+ *
+ * @author Tomasz Linkowski
+ */
+final class SeqBuffer<T> {
+
+    @SuppressWarnings("unchecked")
+    static <T> SeqBuffer<T> of(Stream<? extends T> stream) {
+        return of((Spliterator<T>) stream.spliterator());
+    }
+
+    static <T> SeqBuffer<T> of(Spliterator<T> spliterator) {
+        if (spliterator instanceof SeqBuffer.BufferSpliterator) {
+            return ((SeqBuffer<T>.BufferSpliterator) spliterator).parentSeqBuffer(); // reuse existing SeqBuffer
+        }
+        return new SeqBuffer<>(spliterator);
+    }
+
+    private final Spliterator<T> source;
+    private final List<T> buffer = new ArrayList<>();
+
+    /**
+     * <code>True</code> while <code>source</code> hasn't reported that it's exhausted.
+     *
+     * This volatile field acts as a memory barrier for the contents of <code>source</code> and <code>buffer</code>:
+     *
+     * @link http://www.cs.umd.edu/~pugh/java/memoryModel/jsr-133-faq.html#volatile
+     */
+    private volatile boolean buffering = true;
+
+    private SeqBuffer(Spliterator<T> source) {
+        this.source = Objects.requireNonNull(source);
+    }
+
+    /**
+     * Returns a <code>Seq</code> over given <code>source</code>.
+     *
+     * Although such <code>Seq</code> is not thread-safe by itself, it interacts in a thread-safe way with its
+     * parent <code>SeqBuffer</code>. As a result, each <code>Seq</code> returned by this method can be safely
+     * used on a different thread.
+     */
+    Seq<T> seq() {
+        return Seq.seq(new BufferSpliterator());
+    }
+
+    /**
+     * Special <code>Spliterator</code> whose <code>tryAdvance</code> method can buffer
+     * (i.e. can advance the <code>source</code> spliterator).
+     *
+     * Instances of this class are NOT thread-safe but they interact in a thread-safe way with <code>SeqBuffer</code>.
+     */
+    private class BufferSpliterator implements Spliterator<T> {
+
+        /**
+         * Index of the element that will be returned upon next call to <code>tryAdvance</code> if such element exists.
+         */
+        private int nextIndex = 0;
+
+        //
+        // TRY ADVANCE
+        //
+        @Override
+        public boolean tryAdvance(Consumer<? super T> action) {
+            return buffering // volatile-read (ensures buffer is up-to-date)
+                  ? tryAdvanceThisWithBuffering(action) // slow (synchronized)
+                  : tryAdvanceThisAtOnce(action); // fast (not synchronized)
+        }
+
+        /**
+         * Tries to advance this <code>Spliterator</code> to element at <code>nextIndex</code>,
+         * buffering <code>source</code> elements into <code>buffer</code> if necessary.
+         *
+         * Synchronized on <code>buffer</code> in order to:
+         * - obtain accurate <code>buffer.size()</code>
+         * - safely copy from <code>source</code> to <code>buffer</code> (if needed)
+         * - safely call <code>buffer.get()</code>
+         */
+        private boolean tryAdvanceThisWithBuffering(Consumer<? super T> action) {
+            final T next;
+            synchronized (buffer) {
+                if (!canAdvanceThisWithBuffering())
+                    return false;
+
+                next = advanceThis();
+            }
+
+            action.accept(next); // call "action" outside of synchronized block
+            return true;
+        }
+
+        private boolean canAdvanceThisWithBuffering() {
+            return canAdvanceThisAtOnce() || tryAdvanceSource() && canAdvanceThisAtOnce();
+        }
+
+        private boolean canAdvanceThisAtOnce() {
+            return nextIndex < buffer.size();
+        }
+
+        /**
+         * Buffers (i.e. advances the <code>source</code>) until an item at <code>nextIndex</code>
+         * is added to the <code>buffer</code>, or until the <code>source</code> is exhausted.
+         *
+         * Guarded by: <code>buffer</code>
+         */
+        private boolean tryAdvanceSource() {
+            boolean canAdvanceSource = buffering; // volatile-read (stored in local variable to limit R/W operations)
+            if (!canAdvanceSource) // check again after having synchronized
+                return false;
+
+            do {
+                canAdvanceSource = source.tryAdvance(buffer::add);
+            } while (canAdvanceSource && !canAdvanceThisAtOnce());
+
+            // volatile-write (causes grown buffer and shrunk source to be visible to all threads upon next volatile-read)
+            buffering = canAdvanceSource;
+            return true;
+        }
+
+        private T advanceThis() {
+            return buffer.get(nextIndex++);
+        }
+
+        /**
+         * Called only when buffering has been completed.
+         */
+        private boolean tryAdvanceThisAtOnce(Consumer<? super T> action) {
+            if (!canAdvanceThisAtOnce())
+                return false;
+
+            action.accept(advanceThis());
+            return true;
+        }
+
+        //
+        // ESTIMATE SIZE
+        //
+        @Override
+        public long estimateSize() {
+            return buffering // volatile-read (ensures buffer is up-to-date)
+                  ? estimateSizeDuringBuffering() // slow (synchronized)
+                  : numberOfElementsLeftInBuffer(); // fast (not synchronized)
+        }
+
+        /**
+         * Returns the estimate size of this Spliterator.
+         *
+         * Synchronized to get an accurate sum of <code>buffer.size()</code> and <code>source.estimateSize()</code>.
+         */
+        private long estimateSizeDuringBuffering() {
+            synchronized (buffer) {
+                int leftInBuffer = numberOfElementsLeftInBuffer();
+                if (!buffering) // check again after having synchronized
+                    return leftInBuffer;
+
+                long estimateSize = leftInBuffer + source.estimateSize();
+                // will overflow to negative number if source.estimateSize() reports Long.MAX_VALUE
+                return estimateSize >= 0 ? estimateSize : Long.MAX_VALUE;
+            }
+        }
+
+        private int numberOfElementsLeftInBuffer() {
+            return buffer.size() - nextIndex;
+        }
+
+        //
+        // REMAINING
+        //
+        @Override
+        public Spliterator<T> trySplit() {
+            return null;
+        }
+
+        @Override
+        public int characteristics() {
+            // no synchronization here because source.characteristics() is assumed to be thread-safe
+            return (source.characteristics() & ~Spliterator.CONCURRENT) | Spliterator.ORDERED
+                  | (buffering ? 0 : Spliterator.SIZED);
+        }
+
+        @Override
+        public Comparator<? super T> getComparator() {
+            return source.getComparator();
+        }
+
+        SeqBuffer<T> parentSeqBuffer() {
+            return SeqBuffer.this;
+        }
+    }
+}

--- a/src/test/java/org/jooq/lambda/SeqBufferTest.java
+++ b/src/test/java/org/jooq/lambda/SeqBufferTest.java
@@ -1,0 +1,120 @@
+package org.jooq.lambda;
+
+import org.jooq.lambda.tuple.Tuple2;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Spliterator;
+import java.util.function.Supplier;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Tomasz Linkowski
+ */
+public class SeqBufferTest {
+
+    private final List<Integer> list = asList(1, 2, 3, 4, 5);
+
+    private SeqBuffer<Integer> buffer() {
+        return SeqBuffer.of(list.stream());
+    }
+
+    @Test
+    public void testBufferingSpliteratorFollowedByNonBufferingOne() {
+        SeqBuffer<Integer> buffer = buffer();
+
+        assertEquals(list, buffer.seq().toList()); // call 1: buffering spliterator + complete consumption
+        assertEquals(list, buffer.seq().toList()); // call 2: buffered spliterator + complete consumption
+    }
+
+    @Test
+    public void testTwoBufferingSpliteratorsConsumedOneAfterAnother() {
+        SeqBuffer<Integer> buffer = buffer();
+
+        Seq<Integer> seq1 = buffer.seq(); // call 1: buffering spliterator
+        Seq<Integer> seq2 = buffer.seq(); // call 2: buffering spliterator
+
+        assertEquals(list, seq1.toList()); // complete consumption of 1
+        assertEquals(list, seq2.toList()); // complete consumption of 2
+
+        assertEquals(list, buffer.seq().toList()); // call 3: buffered spliterator + complete consumption
+    }
+
+    @Test
+    public void testTwoBufferingSpliteratorsConsumedInParallel() {
+        SeqBuffer<Integer> buffer = buffer();
+
+        List<Tuple2<Integer, Integer>> expected = Seq.zip(list, list).toList();
+        // calls 1 & 2: two buffering spliterators and parallel consumption of both
+        List<Tuple2<Integer, Integer>> actual = Seq.zip(buffer.seq(), buffer.seq()).toList();
+        assertEquals(expected, actual);
+
+        assertEquals(list, buffer.seq().toList()); // call 3: buffered spliterator + complete consumption
+    }
+
+    @Test
+    public void testTwoBufferedSpliteratorsConsumedInterchangeably() {
+        SeqBuffer<Integer> buffer = buffer();
+
+        // consume some x, then some y, then again some x, etc.
+        Spliterator<Integer> x = buffer.seq().spliterator(); // call 1: buffering spliterator
+        assertTrue(x.tryAdvance(i -> verifyInt(1, i)));
+        assertTrue(x.tryAdvance(i -> verifyInt(2, i)));
+        Spliterator<Integer> y = buffer.seq().spliterator(); // call 2: buffering spliterator
+        assertTrue(y.tryAdvance(i -> verifyInt(1, i)));
+        assertTrue(x.tryAdvance(i -> verifyInt(3, i)));
+        assertTrue(y.tryAdvance(i -> verifyInt(2, i)));
+        assertTrue(y.tryAdvance(i -> verifyInt(3, i)));
+        assertTrue(y.tryAdvance(i -> verifyInt(4, i)));
+        assertTrue(x.tryAdvance(i -> verifyInt(4, i)));
+        assertTrue(x.tryAdvance(i -> verifyInt(5, i)));
+        assertTrue(y.tryAdvance(i -> verifyInt(5, i)));
+        assertFalse(x.tryAdvance(AssertionError::new));
+        assertFalse(y.tryAdvance(AssertionError::new));
+
+        assertEquals(list, buffer.seq().toList()); // call 3: buffered spliterator + complete consumption
+    }
+
+    @Test
+    public void testThreadSafetyDuringParallelConsumption() {
+        int numThreads = 10;
+        int maxVariation = 100;
+        int numElements = 10_000;
+
+        Supplier<Seq<Integer>> s = () -> Seq.range(0, numElements);
+        SeqBuffer<Integer> buffer = SeqBuffer.of(s.get());
+
+        class TestThread extends Thread {
+            private final Random random = new Random();
+            volatile List<Integer> actualList;
+
+            @Override
+            public void run() {
+                actualList = buffer.seq().peek(i -> randomWait()).toList();
+            }
+
+            private void randomWait() {
+                for (int i = 0, variation = random.nextInt(maxVariation); i < variation; i++) {
+                }
+            }
+        }
+
+        List<TestThread> testThreads = Seq.generate(() -> new TestThread()).limit(numThreads).toList();
+        testThreads.forEach(Thread::start);
+        testThreads.forEach(Unchecked.consumer(Thread::join));
+
+        List<Integer> expectedList = s.get().toList();
+        for (TestThread testThread : testThreads) {
+            assertEquals(expectedList, testThread.actualList);
+        }
+    }
+
+    private void verifyInt(int expected, int actual) {
+        assertEquals("Unexpected value", expected, actual);
+    }
+}


### PR DESCRIPTION
I propose a solution to the problems described in #195 for the following methods:
- `crossSelfJoin()` (`crossJoin()` needs to be adapted by @lukaseder in `jOOQ-tools`)
- `inner(Self)Join()`
- `leftOuter(Self)Join()`

The solution for nearly all the remaining methods will consist in applying `Seq.lazy()` to them for which I'll create a separate PR in order to demonstrate its usefulness, as discussed in #302.

---

PS. `SeqBuffer` could be used to create a simpler implementation of `Seq.duplicate`.
PPS. `SeqBuffer` could also be used to implement method `Seq.duplicate(int count)`. Such method would return a `List<Seq<T>>` containing `count` `Seq`s. However, the only application for such method that I can think of is implementing #49 which (to be honest) I don't find very useful either.