### PR TITLE
Add Seq.lazy()

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -4622,7 +4622,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
      * Lazily produce a <code>Seq</code>.
      */
     static <T> Seq<T> lazy(Supplier<? extends Stream<T>> s) {
-        return seq(Stream.of(s).flatMap(Supplier::get));
+        return SeqUtils.lazy(s);
     }
 
     /**

--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -4615,6 +4615,13 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * Lazily produce a <code>Seq</code>.
+     */
+    static <T> Seq<T> lazy(Supplier<? extends Stream<T>> s) {
+        return seq(Stream.of(s).flatMap(Supplier::get));
+    }
+
+    /**
      * Wrap an array slice into a <code>Seq</code>.
      * 
      * @throws IndexOutOfBoundsException if

--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -924,7 +924,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
      * </pre><code>
      */
     default Seq<T> removeAll(Seq<? extends T> other) {
-        return lazy(() -> {
+        return SeqUtils.lazy(() -> {
             Set<? extends T> set = other.toSet(HashSet::new);
             return set.isEmpty() ? this : filter(t -> !set.contains(t)).onClose(other::close);
         });
@@ -975,7 +975,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
      * </pre><code>
      */
     default Seq<T> retainAll(Seq<? extends T> other) {
-        return lazy(() -> {
+        return SeqUtils.lazy(() -> {
             Set<? extends T> set = other.toSet(HashSet::new);
             return set.isEmpty() ? empty() : filter(t -> set.contains(t)).onClose(other::close);
         });
@@ -4619,13 +4619,6 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
-     * Lazily produce a <code>Seq</code>.
-     */
-    static <T> Seq<T> lazy(Supplier<? extends Stream<T>> s) {
-        return SeqUtils.lazy(s);
-    }
-
-    /**
      * Wrap an array slice into a <code>Seq</code>.
      * 
      * @throws IndexOutOfBoundsException if
@@ -6961,7 +6954,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
      * </pre></code>
      */
     static <T> Seq<T> reverse(Seq<? extends T> stream) {
-        return lazy(() -> {
+        return SeqUtils.lazy(() -> {
             List<T> list = toList(stream);
             Collections.reverse(list);
             return seq(list).onClose(stream::close);
@@ -7037,7 +7030,7 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
      * </pre></code>
      */
     static <T> Seq<T> shuffle(Seq<? extends T> stream, Random random) {
-        return lazy(() -> {
+        return SeqUtils.lazy(() -> {
             List<T> list = toList(stream);
             if (random == null)
                 Collections.shuffle(list);


### PR DESCRIPTION
This is my second attempt to propose `Seq.lazy()` (see #302 for details).

Here, I propose it together with the reimplementations of the following methods mentioned in #195 (in order to demonstrate the real usefulness of `Seq.lazy`):
- `shuffle()` (provided simpler implementation)
- `reverse()`
- `removeAll()`
- `retainAll()`
- `window()` (this has to be adapted by @lukaseder in `jOOQ-tools`)

I did not reimplement the following methods (although they eagerly call `iterator()` or `spliterator()`, they do not try to iterate it immediately so they don't seem to be problematic in practice):
- `zip()`, `zipAll()`
- `SeqUtils.transform()`
- `grouped`
- `partition` (returns `Tuple` - could not use `Seq.lazy`)
- `duplicate()` (returns `Tuple` - in this particular case I'd implement it using `SeqBuffer` proposed in #305)

Reimplementation of the remaining methods mentioned in #195 (i.e. all kinds of `join`s) was proposed in #305.