### PR TITLE
Make Seq.flatMap() lazy

### DIFF
--- a/src/main/java/org/jooq/lambda/LazyFlatMapper.java
+++ b/src/main/java/org/jooq/lambda/LazyFlatMapper.java
@@ -19,6 +19,9 @@ import java.util.stream.Stream;
  */
 final class LazyFlatMapper<T, R> {
 
+    /**
+     * Flat maps this stream using given <code>mapper</code> but in a fully lazy way.
+     */
     static <T, R> Seq<R> flatMapLazily(Stream<? extends T> stream, Function<? super T, ? extends Stream<? extends R>> mapper) {
         return new LazyFlatMapper<T, R>(mapper).flatMapLazily(stream);
     }

--- a/src/main/java/org/jooq/lambda/LazyFlatMapper.java
+++ b/src/main/java/org/jooq/lambda/LazyFlatMapper.java
@@ -1,0 +1,121 @@
+package org.jooq.lambda;
+
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Special class that implements a fully lazy <code>flatMap</code> operation.
+ * Default <code>flatMap</code> in <code>Stream</code> is only a partially lazy operation:
+ * @link http://stackoverflow.com/questions/29229373/why-filter-after-flatmap-is-not-completely-lazy-in-java-streams
+ *
+ * This class should not be instantiated outside of the provided static <code>flatMapLazily</code> method.
+ *
+ * @see Stream#flatMap
+ *
+ * @author Tomasz Linkowski
+ */
+final class LazyFlatMapper<T, R> {
+
+    static <T, R> Seq<R> flatMapLazily(Stream<? extends T> stream, Function<? super T, ? extends Stream<? extends R>> mapper) {
+        return new LazyFlatMapper<T, R>(mapper).flatMapLazily(stream);
+    }
+
+    /**
+     * <code>Function</code> provided as the <code>flatMap()</code> argument.
+     *
+     * @see Stream#flatMap
+     */
+    private final Function<? super T, ? extends Stream<? extends R>> flatMapper;
+    /**
+     * Stores last unclosed output stream (or <code>null</code>) in order to close it in due time
+     * (i.e. when the the <code>outStream</code> has been entirely consumed,
+     * or when the resulting flat-mapped stream has been closed) as specified in:
+     *
+     * @see Stream#flatMap
+     */
+    private Stream<? extends R> outStream = null;
+
+    private LazyFlatMapper(Function<? super T, ? extends Stream<? extends R>> flatMapper) {
+        this.flatMapper = Objects.requireNonNull(flatMapper);
+    }
+
+    /**
+     * Creates a <code>FlatMapSpliterator</code>, wraps it in <code>Seq</code>, and registers required close handlers.
+     */
+    private Seq<R> flatMapLazily(Stream<? extends T> inStream) {
+        return Seq.seq(new FlatMapSpliterator(inStream.spliterator()))
+              .onClose(this::closeLastOutStream)
+              .onClose(inStream::close);
+    }
+
+    private void closeLastOutStream() {
+        if (outStream != null) {
+            outStream.close();
+            outStream = null;
+        }
+    }
+
+    /**
+     * <code>SequentialSpliterator</code> performing the flat-map operation on given <code>in</code> spliterator
+     * and using given <code>flatMapper</code> function.
+     */
+    private final class FlatMapSpliterator implements SequentialSpliterator<R> {
+
+        /**
+         * Source spliterator (<code>null</code> if this <code>FlatMapSpliterator</code> has no more elements).
+         */
+        private Spliterator<? extends T> in;
+        /**
+         * Target spliterator (<code>null</code> if this <code>FlatMapSpliterator</code> has not yet been initialized).
+         */
+        private Spliterator<? extends R> out = null;
+
+        private FlatMapSpliterator(Spliterator<? extends T> in) {
+            this.in = Objects.requireNonNull(in);
+        }
+
+        @Override
+        public boolean tryAdvance(Consumer<? super R> action) {
+            if (isExhausted())
+                return false;
+
+            while (!tryAdvanceOutput(action)) {
+                if (!tryAdvanceInput()) {
+                    markAsExhausted();
+                    return false;
+                }
+            }
+            return true; // output has been advanced
+        }
+
+        private boolean tryAdvanceOutput(Consumer<? super R> action) {
+            return out != null && out.tryAdvance(action);
+        }
+
+        private boolean tryAdvanceInput() {
+            return in.tryAdvance(this::initNewOutStream);
+        }
+
+        /**
+         * Switch from current <code>out</code> spliterator (possibly <code>null</code>)
+         * to the next one, flat-mapped from given <code>t</code>.
+         */
+        private void initNewOutStream(T t) {
+            closeLastOutStream();
+            outStream = Objects.requireNonNull(flatMapper.apply(t));
+            out = Objects.requireNonNull(outStream.spliterator());
+        }
+
+        private boolean isExhausted() {
+            return in == null;
+        }
+
+        private void markAsExhausted() {
+            in = null;
+            closeLastOutStream();
+        }
+    }
+}

--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -1025,6 +1025,15 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * Flat maps this stream using given <code>mapper</code> but in a fully lazy way.
+     *
+     * @see Stream#flatMap
+     */
+    default <R> Seq<R> flatMapLazily(Function<? super T, ? extends Stream<? extends R>> mapper) {
+        return LazyFlatMapper.flatMapLazily(this, mapper);
+    }
+
+    /**
      * Zip two streams into one.
      * <p>
      * <code><pre>

--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -1025,15 +1025,6 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
-     * Flat maps this stream using given <code>mapper</code> but in a fully lazy way.
-     *
-     * @see Stream#flatMap
-     */
-    default <R> Seq<R> flatMapLazily(Function<? super T, ? extends Stream<? extends R>> mapper) {
-        return LazyFlatMapper.flatMapLazily(this, mapper);
-    }
-
-    /**
      * Zip two streams into one.
      * <p>
      * <code><pre>
@@ -9849,6 +9840,11 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     @Override
     DoubleStream mapToDouble(ToDoubleFunction<? super T> mapper);
 
+    /**
+     * ATTENTION: this <code>flatMap()</code> does not redirect to <code>Stream</code>!
+     *
+     * @see SeqImpl#flatMap
+     */
     @Override
     <R> Seq<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper);
 

--- a/src/main/java/org/jooq/lambda/SeqImpl.java
+++ b/src/main/java/org/jooq/lambda/SeqImpl.java
@@ -97,7 +97,7 @@ class SeqImpl<T> implements Seq<T> {
 
     @Override
     public <R> Seq<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
-        return Seq.seq(stream().flatMap(mapper));
+        return LazyFlatMapper.flatMapLazily(stream(), mapper);
     }
 
     @Override

--- a/src/main/java/org/jooq/lambda/SequentialSpliterator.java
+++ b/src/main/java/org/jooq/lambda/SequentialSpliterator.java
@@ -1,0 +1,39 @@
+package org.jooq.lambda;
+
+import java.util.Spliterator;
+
+/**
+ * Special subinterface of <code>Spliterator</code> that provides default implementations
+ * for all the methods that are not relevant to sequential traversal.
+ *
+ * @see java.util.stream.BaseStream#sequential
+ *
+ * @author Tomasz Linkowski
+ */
+@FunctionalInterface
+public interface SequentialSpliterator<T> extends Spliterator<T> {
+
+    /**
+     * This spliterator cannot be split.
+     */
+    @Override
+    default Spliterator<T> trySplit() {
+        return null;
+    }
+
+    /**
+     * This spliterator has unknown estimate size.
+     */
+    @Override
+    default long estimateSize() {
+        return Long.MAX_VALUE;
+    }
+
+    /**
+     * This spliterator is treated as ordered because it is <code>sequential</code>.
+     */
+    @Override
+    default int characteristics() {
+        return Spliterator.ORDERED;
+    }
+}

--- a/src/test/java/org/jooq/lambda/LazyFlatMapperTest.java
+++ b/src/test/java/org/jooq/lambda/LazyFlatMapperTest.java
@@ -1,0 +1,228 @@
+package org.jooq.lambda;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Tomasz Linkowski
+ */
+public class LazyFlatMapperTest {
+
+    @Test
+    public void testSimpleSeq() {
+        List<Integer> peekedRegular = obtainElementsPeekedInOrderToFindFirst(simpleFlatMapSeq(false));
+        assertEquals(asList(2, 4, 6), peekedRegular); // at least 2 unnecessary elements
+
+        List<Integer> peekedLazy = obtainElementsPeekedInOrderToFindFirst(simpleFlatMapSeq(true));
+        assertEquals(asList(2), peekedLazy);
+
+        testNecessaryEquality(this::simpleFlatMapSeq);
+    }
+
+    @Test
+    public void testDoublyNestedSeq() {
+        List<Integer> peekedRegular = obtainElementsPeekedInOrderToFindFirst(doublyNestedFlatMapSeq(false));
+        assertEquals(asList(2, 4, 6, 4, 8, 12, 6, 12, 18), peekedRegular); // at least 8 unnecessary elements
+
+        List<Integer> peekedLazy = obtainElementsPeekedInOrderToFindFirst(doublyNestedFlatMapSeq(true));
+        assertEquals(asList(2), peekedLazy);
+
+        testNecessaryEquality(this::doublyNestedFlatMapSeq);
+    }
+
+    @Test
+    public void testVeryComplexSeq() {
+        List<Integer> peekedRegular = obtainElementsPeekedInOrderToFindFirst(veryComplexFlatMapSeq(false));
+        assertEquals(asList(8, 16, 24, 6, 12, 18, 10, 20, 30), peekedRegular); // at least 8 unnecessary elements
+
+        List<Integer> peekedLazy = obtainElementsPeekedInOrderToFindFirst(veryComplexFlatMapSeq(true));
+        assertEquals(asList(8), peekedLazy);
+
+        testNecessaryEquality(this::veryComplexFlatMapSeq);
+    }
+
+    @Test
+    public void testSeqClosesAllResources() {
+        testCloseableFlatMapSeq(
+              regularSeq -> {
+                  List<Integer> peekedRegular = obtainElementsPeekedInOrderToFindFirst(regularSeq);
+                  assertEquals(asList(2, 4, 6), peekedRegular);
+              },
+              lazySeq -> {
+                  List<Integer> peekedLazy = obtainElementsPeekedInOrderToFindFirst(lazySeq);
+                  assertEquals(asList(2), peekedLazy);
+              }
+        );
+
+        testCloseableFlatMapSeq(Collectable::toList);
+        testCloseableFlatMapSeq(seq -> seq.limit(5).toList());
+
+        testNecessaryEquality(lazy -> simpleCloseableFlatMapSeq(lazy, createIdentitySet()));
+    }
+
+    /**
+     * Returns all the elements traversed until <code>findFirst()</code> returned its result.
+     *
+     * This represents the difference between regular <code>flatMap</code> from proposed <code>flatMapLazily</code>
+     * when it was the last operation perform on the stream.
+     */
+    private <T> List<T> obtainElementsPeekedInOrderToFindFirst(Stream<T> stream) {
+        List<T> peeked = new ArrayList<>();
+        stream.peek(peeked::add).findFirst();
+        return peeked;
+    }
+
+    private void testCloseableFlatMapSeq(TestOperation<Integer> seqTestOp) {
+        testCloseableFlatMapSeq(seqTestOp, seqTestOp);
+    }
+
+    /**
+     * Tests consumption of simple (singly-nested) regular and lazy seqs within try-with-resources block,
+     * calling provided test operations.
+     *
+     * Then, after both Seqs have been consumed, ensures the same number of Seqs have been closed in order to make
+     * sure that the lazy implementation indeed closes all the resources it should.
+     */
+    private void testCloseableFlatMapSeq(TestOperation<Integer> regularSeqTestOp, TestOperation<Integer> lazySeqTestOp) {
+        Set<Seq<Integer>> regularClosedSeqs = createIdentitySet();
+        try (Seq<Integer> regularSeq = simpleCloseableFlatMapSeq(false, regularClosedSeqs)) {
+            regularSeqTestOp.consumeSeq(regularSeq);
+        }
+
+        Set<Seq<Integer>> lazyClosedSeqs = createIdentitySet();
+        try (Seq<Integer> lazySeq = simpleCloseableFlatMapSeq(true, lazyClosedSeqs)) {
+            lazySeqTestOp.consumeSeq(lazySeq);
+        }
+
+        assertEquals("closed resources", regularClosedSeqs.size(), lazyClosedSeqs.size());
+    }
+
+    /**
+     * Runs various terminal operations on both regular and lazy seq and tests that they return the same value.
+     */
+    private void testNecessaryEquality(TestSeqProvider<Integer> seqProvider) {
+        testEquality(seqProvider, Collectable::toList);
+        testEquality(seqProvider, Seq::findFirst); // short-circuiting
+        testEquality(seqProvider, Seq::findLast);
+        testEquality(seqProvider, Seq::sum);
+
+        testEquality(seqProvider, seq -> seq.anyMatch(i -> i == 8)); // short-circuiting
+        testEquality(seqProvider, seq -> seq.allMatch(i -> i == 8)); // short-circuiting
+        testEquality(seqProvider, seq -> seq.allMatch(i -> i > 0)); // short-circuiting
+        testEquality(seqProvider, seq -> seq.limit(5).anyMatch(i -> i == 8)); // short-circuiting
+        testEquality(seqProvider, seq -> seq.limit(5).toList());
+        testEquality(seqProvider, seq -> seq.filter(i -> i % 2 == 0).toList());
+    }
+
+    /**
+     * Runs given terminal operation on both regular and lazy seq and test that they return the same value.
+     */
+    private <R> void testEquality(TestSeqProvider<Integer> seqProvider, TestValueOperation<Integer, R> operation) {
+        Seq<Integer> regularSeq = seqProvider.provideSeq(false);
+        Seq<Integer> lazySeq = seqProvider.provideSeq(true);
+        assertEquals(operation.applyToSeq(regularSeq), operation.applyToSeq(lazySeq));
+    }
+
+    private <T> Set<Seq<T>> createIdentitySet() {
+        return Collections.newSetFromMap(new IdentityHashMap<>());
+    }
+
+    private <T> Seq<T> registerCloseHandler(Seq<T> seq, Set<Seq<T>> closedSeqs) {
+        return seq.onClose(() -> closedSeqs.add(seq));
+    }
+
+    /**
+     * Represents any of the method with suffix <code>*FlatMapSeq</code>.
+     */
+    @FunctionalInterface
+    private interface TestSeqProvider<T> {
+        Seq<T> provideSeq(boolean lazy);
+    }
+
+    /**
+     * Represents a function that is applied to get a result from both regular and lazy seq,
+     * so that these results can be compared for equality.
+     */
+    @FunctionalInterface
+    private interface TestValueOperation<T, R> {
+        R applyToSeq(Seq<T> seq);
+    }
+
+    /**
+     * Represents an operation testing this seq, e.g. using assertions.
+     */
+    @FunctionalInterface
+    private interface TestOperation<T> {
+        void consumeSeq(Seq<T> seq);
+    }
+
+    //
+    // TEST DATA
+    //
+    private Seq<Integer> testSeq() {
+        return Seq.of(2, 3, 4);
+    }
+
+    private Seq<Integer> testMap(Integer i) {
+        return Seq.of(i, 2 * i, 3 * i);
+    }
+
+    /**
+     * Simplest flat map operation (flat map called once).
+     */
+    private Seq<Integer> simpleFlatMapSeq(boolean lazy) {
+        return lazy
+              ? testSeq().flatMapLazily(this::testMap)
+              : testSeq().flatMap(this::testMap);
+    }
+
+    /**
+     * Flat map called twice (two levels of flat-mapping).
+     */
+    private Seq<Integer> doublyNestedFlatMapSeq(boolean lazy) {
+        return lazy
+              ? testSeq().flatMapLazily(this::testMap).flatMapLazily(this::testMap)
+              : testSeq().flatMap(this::testMap).flatMap(this::testMap);
+    }
+
+    /**
+     * Flat map called a few times, among many other operations.
+     */
+    private Seq<Integer> veryComplexFlatMapSeq(boolean lazy) {
+        if (lazy) {
+            return testSeq().flatMapLazily(this::testMap).limit(6)
+                  .append(testSeq().filter(i -> i % 2 == 0).onEmpty(2).limitUntil(i -> i > 50))
+                  .flatMapLazily(i -> testMap(i).flatMapLazily(this::testMap).skip(2).limitWhile(j -> j < 10))
+                  .map(i -> i + 2)
+                  .flatMapLazily(this::testMap);
+        } else {
+            return testSeq().flatMap(this::testMap).limit(6)
+                  .append(testSeq().filter(i -> i % 2 == 0).onEmpty(2).limitUntil(i -> i > 50))
+                  .flatMap(i -> testMap(i).flatMap(this::testMap).skip(2).limitWhile(j -> j < 10))
+                  .map(i -> i + 2)
+                  .flatMap(this::testMap);
+        }
+    }
+
+    /**
+     * Simple flat map but with registered close handlers for all Seqs. These close handlers trace whether given Seq
+     * has been closed by adding such Seq to the <code>closedSeqs</code> identity set.
+     */
+    private Seq<Integer> simpleCloseableFlatMapSeq(boolean lazy, Set<Seq<Integer>> closedSeqs) {
+        Seq<Integer> closeableSeq = registerCloseHandler(testSeq(), closedSeqs);
+        Function<Integer, Stream<Integer>> closeableMapper = i -> registerCloseHandler(testMap(i), closedSeqs);
+        return lazy
+              ? closeableSeq.flatMapLazily(closeableMapper)
+              : closeableSeq.flatMap(closeableMapper);
+    }
+}


### PR DESCRIPTION
@lukaseder, I know I've been flooding you with PRs recently, sorry... But this one is a result of my astonishment that `Stream.flatMap` is not a fully lazy operation!

Some (me included) consider this behavior to be a bug: https://bugs.openjdk.java.net/browse/JDK-8075939 But maybe there was some rationale for `Stream.flatMap` not to be fully lazy because `Stream`s may be parallel. However, on `sequential` streams like `Seq`, it seems there is absolutely no justification for `flatMap` to be so eager (but - to quote you - "I'm happy to be proven wrong").

So this PR proposes a `Seq.flatMapLazily()` method which corresponds directly to `Seq.flatMap()` but is fully lazy. I spent an entire day writing this but it was fun :)

Theoretically, we could venture as far as modifying `Seq.flatMap` to call this lazy implementation. On the one hand, it would be better than introducing a new method in `Seq` that doesn't (functionally) do anything new. On the other hand, it seems quite risky because it could potentially break a loooot of client code. Although, for testing on some large codebase (like jOOQ), it'd be a nice thing to do (I mean, to modify `flatMap`, and then run all the tests on the codebase, and see where they fail).

The tests that I've provided in this PR are rather scarcy, and I feel this feature should be **tested much more extensively** before being accepted. I didn't write more because I didn't want to spend too much time on it up front.

I just hope you'll seriously consider and then (hopefully) revise this request (no hurry, of course) because:
- current implementation of sequential `flatMap` looks like a potentially huge waste of resources
- I'd make use of it in my project, and to use it conveniently it needs to be an interface method :)