### PR TITLE
Added Seq.peekThrowable(Consumer<Throwable>)

### DIFF
--- a/src/main/java/org/jooq/lambda/Seq.java
+++ b/src/main/java/org/jooq/lambda/Seq.java
@@ -432,6 +432,21 @@ public interface Seq<T> extends Stream<T>, Iterable<T>, Collectable<T> {
     }
 
     /**
+     * If a throwable occurs during traversal of elements, call the <code>throwableHandler</code>
+     * on this throwable before rethrowing it.
+     */
+    default Seq<T> peekThrowable(Consumer<? super Throwable> throwableHandler) {
+        return SeqUtils.transform(this, (delegate, action) -> {
+            try {
+                return delegate.tryAdvance(action);
+            } catch (Throwable throwable) {
+                throwableHandler.accept(throwable);
+                throw throwable;
+            }
+        });
+    }
+
+    /**
      * Concatenate two streams.
      * <p>
      * <code><pre>

--- a/src/test/java/org/jooq/lambda/SeqTest.java
+++ b/src/test/java/org/jooq/lambda/SeqTest.java
@@ -973,7 +973,7 @@ public class SeqTest {
     }
 
     @Test
-    public void testOnEmpty() throws X {
+    public void testOnEmpty() {
         assertEquals(asList(1), Seq.of().onEmpty(1).toList());
         assertEquals(asList(1), Seq.of().onEmptyGet(() -> 1).toList());
         assertThrows(X.class, () -> Seq.of().onEmptyThrow(() -> new X()).toList());
@@ -988,7 +988,7 @@ public class SeqTest {
     }
 
     @SuppressWarnings("serial")
-    class X extends Exception {}
+    static class X extends RuntimeException {}
 
     @Test
     public void testConcat() {


### PR DESCRIPTION
See #91 and #299.

@lukaseder, you should be aware that the implementation I provided here (which is the same as proposed in #299) does not have the exact semantics you expected. Namely, the following test passes:
```java
// assert throws PeekedX EVEN when "peekThrowable" BEFORE "throw" but on the SAME Spliterator
assertThrows(PeekedX.class, () -> Seq.of(1, 2, 3)
    .peekThrowable(throwable -> {
        throw new PeekedX();
    })
    .peek(i -> {
        if (i == 2)
            throw new X();
    })
    .toList());
```

which means that `peekThrowable` works not only upstream but also downstream. The reason for this is (as far as I understand) that the `action` passed to the top-most (source) `Spliterator.tryAdvance(Consumer<T> action)` represents (in a way) all the cumulated operations (up to the terminal operation).

However, calling `peekThrowable` more up or down the stream can make a difference because we can catch two types of `Throwable`s:
1. Thrown inside `action.apply(T)` - these are caught both upstream and downstream
2. Thrown in the remaining parts of `Spliterator.tryAdvance()` - these are caught only upstream