### PR TITLE
[#296] Added chunked(long), chunked(Predicate<T>)

### DIFF
--- a/src/main/java/org/jooq/lambda/Iterators.java
+++ b/src/main/java/org/jooq/lambda/Iterators.java
@@ -1,0 +1,116 @@
+package org.jooq.lambda;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+/**
+ * Created by billoneil on 7/26/17.
+ */
+public class Iterators {
+    private enum PredicateCheckState { NOT_TESTED, MORE, ONE_MORE, NO_MORE }
+
+    static <E> PeekingIterator<E> peeking(Iterator<E> iterator) {
+        return new PeekingIteratorImpl<E>(iterator);
+    }
+
+    static <E> Iterator<E> takeWhileIterator(Iterator<E> iterator, Predicate<E> predicate) {
+        return takeWhileIterator(peeking(iterator), predicate);
+    }
+
+    static <E> Iterator<E> takeWhileIterator(PeekingIterator<E> iterator, Predicate<E> predicate) {
+        return new Iterator<E>() {
+
+            private final PeekingIterator<E> peeking = iterator;
+            private PredicateCheckState state = PredicateCheckState.NOT_TESTED;
+
+            @Override
+            public boolean hasNext() {
+                // Short circuit since its not possible
+                if (!peeking.hasNext()) {
+                    state = PredicateCheckState.NOT_TESTED;
+                    return false;
+                }
+
+                // We want the predicate test to be deterministic per element
+                // so we need to cache the result until we advance the iterator.
+                // An example predicate would be a counting predicate.
+                if (PredicateCheckState.NOT_TESTED == state) {
+                    boolean stop = predicate.test(peeking.peek());
+                    if (stop) {
+                        state = PredicateCheckState.ONE_MORE;
+                    } else {
+                        state = PredicateCheckState.MORE;
+                    }
+                }
+
+                if (state == PredicateCheckState.NO_MORE) {
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public E next() {
+                if (PredicateCheckState.ONE_MORE == state) {
+                    state = PredicateCheckState.NO_MORE;
+                } else {
+                    state = PredicateCheckState.NOT_TESTED;
+                }
+                return peeking.next();
+            }
+        };
+    }
+
+    static class PeekingIteratorImpl<E> implements PeekingIterator<E> {
+        private final Iterator<E> delegate;
+        private E headElement;
+        private boolean hasPeeked;
+
+        PeekingIteratorImpl(Iterator<E> delegate) {
+            this.delegate = delegate;
+            this.headElement = null;
+            this.hasPeeked = false;
+        }
+
+        @Override
+        public E peek() {
+            if (hasPeeked) {
+                return headElement;
+            }
+            headElement = delegate.next();
+            hasPeeked = true;
+            return headElement;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return hasPeeked || delegate.hasNext();
+        }
+
+        @Override
+        public E next() {
+            if (hasPeeked) {
+                hasPeeked = false;
+                return headElement;
+            }
+            return delegate.next();
+        }
+    }
+
+    static <T> Predicate<T> countingPredicate(long count) {
+        if (count < 1) {
+            throw new IllegalArgumentException("count must be greater than 1");
+        }
+        long[] countArray = new long[1];
+        countArray[0] = 0L;
+        long iterations = count -1;
+        return (T t) -> {
+            if (iterations == countArray[0]) {
+                countArray[0] = 0L;
+                return true;
+            }
+            countArray[0] = countArray[0] + 1;
+            return false;
+        };
+    }
+}

--- a/src/main/java/org/jooq/lambda/PeekingIterator.java
+++ b/src/main/java/org/jooq/lambda/PeekingIterator.java
@@ -1,0 +1,13 @@
+package org.jooq.lambda;
+
+import java.util.Iterator;
+
+public interface PeekingIterator<E> extends Iterator<E> {
+    /**
+     * Returns the current head of the iterator without consuming it.
+     * Multiple sequential calls to {@code peek()} will return the same element.
+     * @return The current head of the iterator
+     * @throws java.util.NoSuchElementException if there are no more elements
+     */
+    E peek();
+}

--- a/src/test/java/org/jooq/lambda/IteratorsTest.java
+++ b/src/test/java/org/jooq/lambda/IteratorsTest.java
@@ -1,0 +1,91 @@
+package org.jooq.lambda;
+
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by billoneil on 7/26/17.
+ */
+public class IteratorsTest {
+
+    @Test(expected = NoSuchElementException.class)
+    public void testPeekingThrows() {
+        Seq<Integer> seq1 = Seq.of();
+        PeekingIterator<Integer> peeking1 = new Iterators.PeekingIteratorImpl<>(seq1.iterator());
+        peeking1.next();
+    }
+
+    @Test
+    public void testPeeking() {
+        Seq<Integer> seq1 = Seq.of();
+        PeekingIterator<Integer> peeking1 = new Iterators.PeekingIteratorImpl<>(seq1.iterator());
+        assertFalse(peeking1.hasNext());
+
+        Seq<Integer> seq2 = Seq.of(1, 2, 3);
+        PeekingIterator<Integer> peeking2 = new Iterators.PeekingIteratorImpl<>(seq2.iterator());
+        int i = 0;
+        while (peeking2.hasNext()) {
+            assertEquals(++i, (int) peeking2.next());
+        }
+
+        Seq<Integer> seq3 = Seq.of(1, 2, 3);
+        PeekingIterator<Integer> peeking3 = new Iterators.PeekingIteratorImpl<>(seq3.iterator());
+        assertEquals(1, (int) peeking3.peek());
+        assertEquals(1, (int) peeking3.peek());
+        assertEquals(1, (int) peeking3.next());
+        assertEquals(2, (int) peeking3.next());
+        assertEquals(3, (int) peeking3.peek());
+        assertEquals(3, (int) peeking3.peek());
+        assertEquals(3, (int) peeking3.next());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCountingPredicateThrowsIllegalArg() {
+        Iterators.countingPredicate(0L);
+    }
+
+    @Test
+    public void testCountingPredicate() {
+        Predicate<Integer> oneCount = Iterators.countingPredicate(1L);
+        assertTrue(oneCount.test(1));
+
+        Predicate<Integer> tenCount = Iterators.countingPredicate(10L);
+        Seq.range(0, 9).forEach(n -> {
+            assertFalse(tenCount.test(n));
+        });
+        assertTrue(tenCount.test(1));
+    }
+
+    @Test
+    public void testPredicateIterator() {
+        Predicate<Integer> tenCount = Iterators.countingPredicate(10L);
+        Seq<Integer> seq = Seq.range(0, 10).cycle();
+        Iterator<Integer> it = Iterators.takeWhileIterator(seq.iterator(), tenCount);
+        int i = 0;
+        while (it.hasNext()) {
+            // It should be safe to call hasNext multiple times.
+            it.hasNext();
+            it.next();
+            i++;
+        }
+        assertEquals(10, i);
+
+
+        Predicate<Integer> isEven = n -> n %2 == 0;
+        Seq<Integer> seq2 = Seq.of(1,1,2,3).cycle();
+        Iterator<Integer> it2 = Iterators.takeWhileIterator(seq2.iterator(), isEven);
+        assertTrue(it2.hasNext());
+        assertTrue(it2.hasNext());
+        assertEquals(1, (int) it2.next());
+        assertEquals(1, (int) it2.next());
+        assertTrue(it2.hasNext());
+        assertEquals(2, (int) it2.next());
+        assertFalse(it2.hasNext());
+    }
+}

--- a/src/test/java/org/jooq/lambda/SeqTest.java
+++ b/src/test/java/org/jooq/lambda/SeqTest.java
@@ -1286,6 +1286,44 @@ public class SeqTest {
     }
 
     @Test
+    public void testChunked() {
+        Seq<Seq<Integer>> seq1 = Seq.range(0, 10).chunked(5);
+        List<List<Integer>> expected1 = Seq.of(
+            Seq.of(0, 1, 2, 3, 4),
+            Seq.of(5, 6, 7, 8, 9)
+        ).map(s -> s.toList()).toList();
+        assertEquals(expected1, seq1.map(s -> s.toList()).toList());
+
+        Seq<Seq<Integer>> seq2 = Seq.range(0, 10).chunked(3);
+        List<List<Integer>> expected2 = Seq.of(
+            Seq.of(0, 1, 2),
+            Seq.of(3, 4, 5),
+            Seq.of(6, 7, 8),
+            Seq.of(9)
+        ).map(s -> s.toList()).toList();
+        assertEquals(expected2, seq2.map(s -> s.toList()).toList());
+
+        // Show that it is lazy
+        Seq<Seq<Integer>> seq3 = Seq.range(0, 10).cycle().chunked(5);
+        List<List<Integer>> expected3 = Seq.of(
+                Seq.of(0, 1, 2, 3, 4),
+                Seq.of(5, 6, 7, 8, 9),
+                Seq.of(0, 1, 2, 3, 4)
+        ).map(s -> s.toList()).toList();
+        assertEquals(expected3, seq3.limit(3).map(s -> s.toList()).toList());
+
+        Predicate<Integer> isEven = n -> n % 2 == 0;
+        Seq<Seq<Integer>> seq4 = Seq.of(1,1,2,2,3,3,3,4).cycle().chunked(isEven);
+        List<List<Integer>> expected4 = Seq.of(
+                Seq.of(1, 1, 2),
+                Seq.of(2),
+                Seq.of(3, 3, 3, 4),
+                Seq.of(1, 1, 2)
+        ).map(s -> s.toList()).toList();
+        assertEquals(expected4, seq4.limit(4).map(s -> s.toList()).toList());
+    }
+
+    @Test
     public void testMinByMaxBy() {
         Supplier<Seq<Integer>> s = () -> Seq.of(1, 2, 3, 4, 5, 6);
 


### PR DESCRIPTION
#296
I have two of the implementations working and they should be truly lazy.

- [x] chunked(long chunkSize)
- [x] chunked(Predicate<T> predicate)
- [ ] chunked(Predicate<T> predicate, boolean excludeDelimiter) ?
- [ ] chunkedWithIndex(BiPredicate<T, Long> biPredicate)

I'm not sure happy with how the code turned out. The two iterators are a little dependent on each other. Maybe a better approach would be to make a more top level peeking iterator instead of hacking it like I did.