### PR TITLE
[#350] allow creation of unbounded Ranges

### DIFF
--- a/jOOL-java-8/src/main/java/org/jooq/lambda/tuple/Range.java
+++ b/jOOL-java-8/src/main/java/org/jooq/lambda/tuple/Range.java
@@ -35,18 +35,23 @@ public class Range<T extends Comparable<T>> extends Tuple2<T, T> {
     }
 
     private static <T extends Comparable<T>> Tuple2<T, T> r(T t1, T t2) {
-        return t1.compareTo(t2) <= 0 ? new Tuple2<>(t1, t2) : new Tuple2<>(t2, t1);
+        if (t1 != null && t2 != null)
+            return t1.compareTo(t2) <= 0 ? new Tuple2<>(t1, t2) : new Tuple2<>(t2, t1);
+        else
+            return new Tuple2<>(t1, t2);
     }
 
     /**
-     * Whether two ranges overlap.
+     * Whether two ranges overlap. Assumes inclusiveness.
      * <p>
      * <code><pre>
      * // true
      * range(1, 3).overlaps(range(2, 4))
+     * range(1, null).overlaps(range(null, 1))
      *
      * // false
      * range(1, 3).overlaps(range(5, 8))
+     * range(null, 3).overlaps(range(5, null))
      * </pre></code>
      */
     public boolean overlaps(Tuple2<T, T> other) {
@@ -96,5 +101,39 @@ public class Range<T extends Comparable<T>> extends Tuple2<T, T> {
      */
     public Optional<Range<T>> intersect(T t1, T t2) {
         return intersect(new Range<>(t1, t2));
+    }
+
+    /**
+     * Whether the given value is included in the range. Assumes range inclusiveness.
+     * <p>
+     * <code><pre>
+     * // true
+     * range(1, 3).contains(1)
+     * range(2, null).contains(5)
+     *
+     * // false
+     * range(1, 3).contains(4)
+     * range(2, null).contains(1)
+     * </pre></code>
+     */
+    public boolean contains(T t) {
+        return Tuple2.contains(this, t);
+    }
+
+    /**
+     * Whether the given right tuple is included in the left tuple.
+     * <p>
+     * <code><pre>
+     * // true
+     * range(1, 3).contains(range(1, 2))
+     * range(2, null).contains(range(3, 5))
+     *
+     * // false
+     * range(1, 3).contains(range(null, 2))
+     * range(2, null).contains(range(1, 3))
+     * </pre></code>
+     */
+    public boolean contains(Tuple2<T, T> other) {
+        return Tuple2.contains(this, other);
     }
 }

--- a/jOOL-java-8/src/test/java/org/jooq/lambda/TupleTest.java
+++ b/jOOL-java-8/src/test/java/org/jooq/lambda/TupleTest.java
@@ -15,34 +15,18 @@
  */
 package org.jooq.lambda;
 
-import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.averagingInt;
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.mapping;
-import static org.jooq.lambda.tuple.Tuple.collectors;
-import static org.jooq.lambda.tuple.Tuple.range;
-import static org.jooq.lambda.tuple.Tuple.tuple;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.jooq.lambda.tuple.Tuple2;
+import org.jooq.lambda.tuple.Tuple5;
+import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Stream;
 
-import org.jooq.lambda.tuple.Tuple2;
-
-import org.jooq.lambda.tuple.Tuple5;
-import org.junit.Assert;
-import org.junit.Test;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.*;
+import static org.jooq.lambda.tuple.Tuple.*;
+import static org.junit.Assert.*;
 
 /**
  * @author Lukas Eder
@@ -200,6 +184,27 @@ public class TupleTest {
     }
 
     @Test
+    public void testOverlaps_withInfiniteBounds() {
+        assertTrue(range((Integer) null, null).overlaps(range(1, 3)));
+        assertTrue(range(1, 3).overlaps(range(null, null)));
+
+        assertTrue(range(3, null).overlaps(range(2, 3)));
+        assertFalse(range(3, null).overlaps(range(1, 2)));
+        assertTrue(range(3, null).overlaps(range(null, 3)));
+        assertFalse(range(3, null).overlaps(range(null, 2)));
+
+        assertTrue(range(2, 3).overlaps(range(3, null)));
+        assertFalse(range(2, 3).overlaps(range(4, null)));
+        assertTrue(range(2, 3).overlaps(range(null, 2)));
+        assertFalse(range(2, 3).overlaps(range(null, 1)));
+
+        assertTrue(range(null, 3).overlaps(tuple(3, null)));
+        assertFalse(range(null, 3).overlaps((tuple(4, null))));
+        assertTrue(range(null, 3).overlaps(tuple(3, 5)));
+        assertFalse(range(null, 3).overlaps((tuple(4, 6))));
+    }
+
+    @Test
     public void testIntersect() {
         assertEquals(Optional.of(tuple(2, 3)), range(1, 3).intersect(range(2, 4)));
         assertEquals(Optional.of(tuple(2, 3)), range(3, 1).intersect(range(4, 2)));
@@ -210,6 +215,37 @@ public class TupleTest {
     @Test
     public void testRange() {
         assertEquals(range(1, 3), range(3, 1));
+        assertNotEquals(range(1, null), range(null, 1));
+    }
+
+    @Test
+    public void testRangeContainsValue() {
+        assertTrue(range(1, 3).contains(1));
+        assertTrue(range(1, 3).contains(2));
+        assertTrue(range(1, 3).contains(3));
+        assertFalse(range(1, 3).contains(0));
+        assertFalse(range(1, 3).contains(4));
+        assertFalse(range(1, 3).contains(-1));
+        assertFalse(range(1, 3).contains(50));
+
+        assertTrue(range(null, 3).contains(1));
+        assertTrue(range((Integer) null, null).contains(1));
+        assertFalse(range(null, 3).contains(4));
+    }
+
+    @Test
+    public void testRangeContainsRange() {
+        assertTrue(range(1, 3).contains(range(1, 1)));
+        assertTrue(range(1, 3).contains(range(1, 2)));
+        assertTrue(range(1, 3).contains(range(1, 3)));
+        assertFalse(range(1, 3).contains(range(0, 1)));
+        assertFalse(range(1, 3).contains(range(1, 4)));
+        assertFalse(range(1, 3).contains(range(-1, 1)));
+        assertFalse(range(1, 3).contains(range(1, 50)));
+
+        assertTrue(range(null, 3).contains(range(1, 2)));
+        assertTrue(range((Integer) null, null).contains(range(1, 5)));
+        assertFalse(range(null, 3).contains(range(1, 4)));
     }
 
     @Test


### PR DESCRIPTION
The class `org.jooq.lambda.tuple.Range` does not support nullable bounds.

For example in PostgreSQL a lower range bound of value `null` means `-infinity`.

See the [Range Types documentation](https://www.postgresql.org/docs/11/rangetypes.html#RANGETYPES-INFINITE):
> The lower bound of a range can be omitted, meaning that all points less than the upper bound are included in the range.


E.g. when testing that the range `(,3)` contains the value `-12`:
```
# SELECT '(,3)'::INT4RANGE @> -12;
 ?column?
----------
 t
(1 row)
```

## What's left to do in this PR
I did not update the method `Tuple2.intersect` to handle null bounds, because it's a bit complicated, and I want to make sure that people support this PR before making this last effort :smile:.

## Other possible improvements
- support bound inclusiveness or exclusiveness (in documentation "[Inclusive and Exclusive Bounds](https://www.postgresql.org/docs/11/rangetypes.html#RANGETYPES-INCLUSIVITY)")
- port more functions than `intersect` and `overlaps` (in documentation "[Range Functions and Operators](https://www.postgresql.org/docs/11/functions-range.html)")

## Usage example

For PostgreSQL type `tstzrange`:

```java
public class TsTzRangeBinding implements Binding<Object, Range<Instant>> {

    public class TsTzRangeConverter implements Converter<Object, Range<Instant>> {

        private static final Pattern PATTERN = Pattern.compile("\\[(.*?),(.*?)\\)");

        @Override
        public Range<Instant> from(Object t) {
            if (t == null) {
                return null;
            }

            Matcher m = PATTERN.matcher("" + t);
            if (m.find()) {
                return new Range<>(Instant.parse(m.group(1)), Instant.parse(m.group(2)));
            }

            throw new IllegalArgumentException("Unsupported range : " + t);
        }

        @Override
        public Object to(Range<Instant> u) {
            return u == null ? null : "[" + emptyIfNull(u.v1) + "," + emptyIfNull(u.v2) + ")";
        }

        private String emptyIfNull(Instant i) {
            return i == null ? "" : i.toString();
        }

        @Override
        public Class<Object> fromType() {
            return Object.class;
        }

        @SuppressWarnings({"unchecked", "rawtypes"})
        @Override
        public Class<Range<Instant>> toType() {
            return (Class) Range.class;
        }

    }

    @Override
    public Converter<Object, Range<Instant>> converter() {
        return new TsTzRangeConverter();
    }

    @Override
    public void sql(BindingSQLContext<Range<Instant>> ctx) {
        ctx.render()
                .visit(DSL.val(ctx.convert(converter()).value()))
                .sql("::TSTZRANGE");
    }

    // ...
}

```
... And register the binding:
```java
ForcedType tstzrange = new ForcedType()
                .withUserType("org.jooq.lambda.tuple.Range<Instant>")
                .withBinding("org.artus.jooq.binding.TsTzRangeBinding")
                .withTypes("tstzrange");
```