### PR TITLE
#221 Add percentileAll and medianAll

### DIFF
--- a/jOOL-java-8/src/main/java/org/jooq/lambda/Agg.java
+++ b/jOOL-java-8/src/main/java/org/jooq/lambda/Agg.java
@@ -941,8 +941,108 @@ public class Agg {
     }
 
     /**
-     * Get a {@link Collector} that calculates the common prefix of a set of strings.
+     * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
      */
+    public static <T extends Comparable<? super T>> Collector<T, ?, Seq<T>> percentileAll(double percentile) {
+        return percentileAllBy(percentile, t -> t, naturalOrder());
+    }
+
+    /**
+     * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
+     */
+    public static <T> Collector<T, ?, Seq<T>> percentileAll(double percentile, Comparator<? super T> comparator) {
+        return percentileAllBy(percentile, t -> t, comparator);
+    }
+
+    /**
+     * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
+     */
+    public static <T, U extends Comparable<? super U>> Collector<T, ?, Seq<T>> percentileAllBy(double percentile, Function<? super T, ? extends U> function) {
+        return percentileAllBy(percentile, function, naturalOrder());
+    }
+
+    /**
+     * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
+     */
+    public static <T, U> Collector<T, ?, Seq<T>> percentileAllBy(double percentile, Function<? super T, ? extends U> function, Comparator<? super U> comparator) {
+        if (percentile < 0.0 || percentile > 1.0)
+            throw new IllegalArgumentException("Percentile must be between 0.0 and 1.0");
+
+        if (percentile == 0.0)
+            // If percentile is 0, this is the same as taking the items with the minimum value.
+            return minAllBy(function, comparator);
+        else if (percentile == 1.0)
+            // If percentile is 1, this is the same as taking the items with the maximum value.
+            return maxAllBy(function, comparator);
+
+        return Collector.of(
+                () -> new ArrayList<Tuple2<? extends T, U>>(),
+                (l, v) -> l.add(tuple(v, function.apply(v))),
+                (l1, l2) -> {
+                    l1.addAll(l2);
+                    return l1;
+                },
+                l -> {
+                    int size = l.size();
+
+                    if (size == 0)
+                        return Seq.empty();
+                    else if (size == 1)
+                        return Seq.of(l.get(0).v1);
+
+                    l.sort(Comparator.comparing(t -> t.v2, comparator));
+
+                    int left = 0, right = (int) -Math.round(-(size * percentile + 0.5)) - 1, mid;
+
+                    List<T> result = new ArrayList<>();
+                    U value = l.get(right).v2;
+                    // Search the first value equal to the value at the position of PERCENTILE by binary search
+                    while (left < right) {
+                        mid = left + (right - left) / 2;
+                        if (comparator.compare(l.get(mid).v2, value) < 0)
+                            left = mid + 1;
+                        else
+                            right = mid;
+                    }
+
+                    for (left++; left < size && comparator.compare(l.get(left).v2, value) == 0; left++)
+                        result.add(l.get(left).v1);
+                    return Seq.seq(result);
+                }
+        );
+    }
+
+    /**
+     * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
+     */
+    public static <T extends Comparable<? super T>> Collector<T, ?, Seq<T>> medianAll() {
+        return medianAllBy(t -> t, naturalOrder());
+    }
+
+    /**
+     * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
+     */
+    public static <T> Collector<T, ?, Seq<T>> medianAll(Comparator<? super T> comparator) {
+        return medianAllBy(t -> t, comparator);
+    }
+
+    /**
+     * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
+     */
+    public static <T, U extends Comparable<? super U>> Collector<T, ?, Seq<T>> medianAllBy(Function<? super T, ? extends U> function) {
+        return medianAllBy(function, naturalOrder());
+    }
+
+    /**
+     * Get a {@link Collector} that calculates the derived <code>MEDIAN()</code> function given natural ordering, producing multiple results.
+     */
+    public static <T, U> Collector<T, ?, Seq<T>> medianAllBy(Function<? super T, ? extends U> function, Comparator<? super U> comparator) {
+        return percentileAllBy(0.5, function, comparator);
+    }
+
+        /**
+         * Get a {@link Collector} that calculates the common prefix of a set of strings.
+         */
     public static Collector<CharSequence, ?, String> commonPrefix() {
         return Collectors.collectingAndThen(
             Collectors.reducing((CharSequence s1, CharSequence s2) -> {

--- a/jOOL-java-8/src/main/java/org/jooq/lambda/Agg.java
+++ b/jOOL-java-8/src/main/java/org/jooq/lambda/Agg.java
@@ -941,6 +941,7 @@ public class Agg {
     }
 
     /**
+     * CS304 Issue link: https://github.com/jOOQ/jOOL/issues/221
      * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
      */
     public static <T extends Comparable<? super T>> Collector<T, ?, Seq<T>> percentileAll(double percentile) {
@@ -948,6 +949,7 @@ public class Agg {
     }
 
     /**
+     * CS304 Issue link: https://github.com/jOOQ/jOOL/issues/221
      * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
      */
     public static <T> Collector<T, ?, Seq<T>> percentileAll(double percentile, Comparator<? super T> comparator) {
@@ -955,6 +957,7 @@ public class Agg {
     }
 
     /**
+     * CS304 Issue link: https://github.com/jOOQ/jOOL/issues/221
      * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
      */
     public static <T, U extends Comparable<? super U>> Collector<T, ?, Seq<T>> percentileAllBy(double percentile, Function<? super T, ? extends U> function) {
@@ -962,6 +965,7 @@ public class Agg {
     }
 
     /**
+     * CS304 Issue link: https://github.com/jOOQ/jOOL/issues/221
      * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
      */
     public static <T, U> Collector<T, ?, Seq<T>> percentileAllBy(double percentile, Function<? super T, ? extends U> function, Comparator<? super U> comparator) {
@@ -992,7 +996,9 @@ public class Agg {
 
                     l.sort(Comparator.comparing(t -> t.v2, comparator));
 
-                    int left = 0, right = (int) -Math.round(-(size * percentile + 0.5)) - 1, mid;
+                    int left = 0;
+                    int right = (int) -Math.round(-(size * percentile + 0.5)) - 1;
+                    int mid;
 
                     List<T> result = new ArrayList<>();
                     U value = l.get(right).v2;
@@ -1005,7 +1011,7 @@ public class Agg {
                             right = mid;
                     }
 
-                    for (left++; left < size && comparator.compare(l.get(left).v2, value) == 0; left++)
+                    for (; left < size && comparator.compare(l.get(left).v2, value) == 0; left++)
                         result.add(l.get(left).v1);
                     return Seq.seq(result);
                 }
@@ -1013,6 +1019,7 @@ public class Agg {
     }
 
     /**
+     * CS304 Issue link: https://github.com/jOOQ/jOOL/issues/221
      * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
      */
     public static <T extends Comparable<? super T>> Collector<T, ?, Seq<T>> medianAll() {
@@ -1020,6 +1027,7 @@ public class Agg {
     }
 
     /**
+     * CS304 Issue link: https://github.com/jOOQ/jOOL/issues/221
      * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
      */
     public static <T> Collector<T, ?, Seq<T>> medianAll(Comparator<? super T> comparator) {
@@ -1027,6 +1035,7 @@ public class Agg {
     }
 
     /**
+     * CS304 Issue link: https://github.com/jOOQ/jOOL/issues/221
      * Get a {@link Collector} that calculates the derived <code>PERCENTILE_DISC(percentile)</code> function given a specific ordering, producing multiple results.
      */
     public static <T, U extends Comparable<? super U>> Collector<T, ?, Seq<T>> medianAllBy(Function<? super T, ? extends U> function) {
@@ -1034,15 +1043,16 @@ public class Agg {
     }
 
     /**
+     * CS304 Issue link: https://github.com/jOOQ/jOOL/issues/221
      * Get a {@link Collector} that calculates the derived <code>MEDIAN()</code> function given natural ordering, producing multiple results.
      */
     public static <T, U> Collector<T, ?, Seq<T>> medianAllBy(Function<? super T, ? extends U> function, Comparator<? super U> comparator) {
         return percentileAllBy(0.5, function, comparator);
     }
 
-        /**
-         * Get a {@link Collector} that calculates the common prefix of a set of strings.
-         */
+    /**
+    * Get a {@link Collector} that calculates the common prefix of a set of strings.
+    */
     public static Collector<CharSequence, ?, String> commonPrefix() {
         return Collectors.collectingAndThen(
             Collectors.reducing((CharSequence s1, CharSequence s2) -> {

--- a/jOOL-java-8/src/test/java/org/jooq/lambda/CollectorTests.java
+++ b/jOOL-java-8/src/test/java/org/jooq/lambda/CollectorTests.java
@@ -15,25 +15,14 @@
  */
 package org.jooq.lambda;
 
-import static org.jooq.lambda.Agg.allMatch;
-import static org.jooq.lambda.Agg.anyMatch;
-import static org.jooq.lambda.Agg.denseRank;
-import static org.jooq.lambda.Agg.denseRankBy;
-import static org.jooq.lambda.Agg.max;
-import static org.jooq.lambda.Agg.maxBy;
-import static org.jooq.lambda.Agg.median;
-import static org.jooq.lambda.Agg.min;
-import static org.jooq.lambda.Agg.minBy;
-import static org.jooq.lambda.Agg.noneMatch;
-import static org.jooq.lambda.Agg.percentRank;
-import static org.jooq.lambda.Agg.percentile;
-import static org.jooq.lambda.Agg.percentileBy;
-import static org.jooq.lambda.Agg.rank;
-import static org.jooq.lambda.Agg.rankBy;
+import static java.util.Arrays.asList;
+import static org.jooq.lambda.Agg.*;
 import static org.jooq.lambda.tuple.Tuple.tuple;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Comparator;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 
@@ -308,7 +297,225 @@ public class CollectorTests {
         Utils.assertThrows(IllegalArgumentException.class, () -> Stream.of("a").collect(percentileBy(2, String::length)));
     }
 
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
     @Test
+    public void testPercentileAllByWithComparator() {
+        Supplier<Seq<String>> s = () -> Seq.of("lll1", "s1", "lll2", "mm1", "mm2", "lll3", "s2", "mm3", "s3", "lll4");
+
+        assertEquals(asList("lll1", "lll2", "lll3", "lll4"), s.get().collect(percentileAllBy(0.25, String::length, Comparator.comparingInt(o -> -o))).toList());
+        assertEquals(asList("mm1", "mm2", "mm3"), s.get().collect(percentileAllBy(0.5, String::length, Comparator.comparingInt(o -> -o))).toList());
+        assertEquals(asList("s1", "s2", "s3"), s.get().collect(percentileAllBy(0.75, String::length, Comparator.comparingInt(o -> -o))).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testPercentileAllByWithComparatorInBoundaryConditions() {
+        Supplier<Seq<String>> s = () -> Seq.of("lll1", "s1", "lll2", "mm1", "mm2", "lll3", "s2", "mm3", "s3", "lll4");
+
+        // Illegal args
+        Utils.assertThrows(IllegalArgumentException.class, () -> s.get().collect(percentileAllBy(-1, String::length, Comparator.comparingInt(o -> -o))));
+        Utils.assertThrows(IllegalArgumentException.class, () -> s.get().collect(percentileAllBy(2, String::length, Comparator.comparingInt(o -> -o))));
+
+        // MaxAllBy
+        assertEquals(asList("s1", "s2", "s3"), s.get().collect(percentileAllBy(1.0, String::length, Comparator.comparingInt(o -> -o))).toList());
+        // MinAllBy
+        assertEquals(asList("lll1", "lll2", "lll3", "lll4"), s.get().collect(percentileAllBy(0.0, String::length, Comparator.comparingInt(o -> -o))).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testPercentileAllByWithoutComparator() {
+        Supplier<Seq<String>> s = () -> Seq.of("lll1", "s1", "lll2", "mm1", "mm2", "lll3", "s2", "mm3", "s3", "lll4");
+
+        assertEquals(asList("s1", "s2", "s3"), s.get().collect(percentileAllBy(0.25, String::length)).toList());
+        assertEquals(asList("mm1", "mm2", "mm3"), s.get().collect(percentileAllBy(0.5, String::length)).toList());
+        assertEquals(asList("lll1", "lll2", "lll3", "lll4"), s.get().collect(percentileAllBy(0.75, String::length)).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testPercentileAllByWithoutComparatorInBoundaryConditions() {
+        Supplier<Seq<String>> s = () -> Seq.of("lll1", "s1", "lll2", "mm1", "mm2", "lll3", "s2", "mm3", "s3", "lll4");
+
+        // Illegal args
+        Utils.assertThrows(IllegalArgumentException.class, () -> s.get().collect(percentileAllBy(-1, String::length)));
+        Utils.assertThrows(IllegalArgumentException.class, () -> s.get().collect(percentileAllBy(2, String::length)));
+
+        // MaxAllBy
+        assertEquals(asList("lll1", "lll2", "lll3", "lll4"), s.get().collect(percentileAllBy(1.0, String::length)).toList());
+        // MinAllBy
+        assertEquals(asList("s1", "s2", "s3"), s.get().collect(percentileAllBy(0.0, String::length)).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testPercentileAllWithComparator() {
+        Supplier<Seq<Integer>> s = () -> Seq.of(1, 3, 2, 1, 2, 1, 2, 3, 3, 2);
+
+        assertEquals(asList(3, 3, 3), s.get().collect(percentileAll(0.25, Comparator.comparingInt(o -> -o))).toList());
+        assertEquals(asList(2, 2, 2, 2), s.get().collect(percentileAll(0.5, Comparator.comparingInt(o -> -o))).toList());
+        assertEquals(asList(1, 1, 1), s.get().collect(percentileAll(0.75, Comparator.comparingInt(o -> -o))).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testPercentileAllWithComparatorInBoundaryConditions() {
+        Supplier<Seq<Integer>> s = () -> Seq.of(1, 3, 2, 1, 2, 1, 2, 3, 3, 2);
+
+        // Illegal args
+        Utils.assertThrows(IllegalArgumentException.class, () -> s.get().collect(percentileAll(-1, Comparator.comparingInt(o -> -o))));
+        Utils.assertThrows(IllegalArgumentException.class, () -> s.get().collect(percentileAll(2, Comparator.comparingInt(o -> -o))));
+
+        // MaxAllBy
+        assertEquals(asList(1, 1, 1), s.get().collect(percentileAll(1.0, Comparator.comparingInt(o -> -o))).toList());
+        // MinAllBy
+        assertEquals(asList(3, 3, 3), s.get().collect(percentileAll(0.0, Comparator.comparingInt(o -> -o))).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testPercentileAllWithoutComparator() {
+        Supplier<Seq<Integer>> s = () -> Seq.of(1, 3, 2, 1, 2, 1, 2, 3, 3, 2);
+
+        assertEquals(asList(1, 1, 1), s.get().collect(percentileAll(0.25)).toList());
+        assertEquals(asList(2, 2, 2, 2), s.get().collect(percentileAll(0.5)).toList());
+        assertEquals(asList(3, 3, 3), s.get().collect(percentileAll(0.75)).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testPercentileAllWithoutComparatorInBoundaryConditions() {
+        Supplier<Seq<Integer>> s = () -> Seq.of(1, 3, 2, 1, 2, 1, 2, 3, 3, 2);
+
+        // Illegal args
+        Utils.assertThrows(IllegalArgumentException.class, () -> s.get().collect(percentileAll(-1)));
+        Utils.assertThrows(IllegalArgumentException.class, () -> s.get().collect(percentileAll(2)));
+
+        // MaxAllBy
+        assertEquals(asList(3, 3, 3), s.get().collect(percentileAll(1.0)).toList());
+        // MinAllBy
+        assertEquals(asList(1, 1, 1), s.get().collect(percentileAll(0.0)).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testMedianAllByWithComparator() {
+        assertEquals(asList("mm1", "mm2", "mm3"), Seq.of("lll1", "s1", "lll2", "mm1", "mm2", "lll3", "s2", "mm3", "s3", "lll4").collect(medianAllBy(String::length, Comparator.comparingInt(o -> -o))).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testMedianAllByWithComparator2() {
+        class Item {
+            final int val;
+            Item(int val) {
+                this.val = val;
+            }
+        }
+
+        Item    a = new Item(1), b = new Item(1), c = new Item(2), d = new Item(2),
+                e = new Item(2), f = new Item(3), g = new Item(3), h = new Item(3),
+                i = new Item(4), j = new Item(4), k = new Item(5), l = new Item(6),
+                m = new Item(7), n = new Item(7), o = new Item(7), p = new Item(7);
+
+        assertEquals(asList(j, i), Seq.of(c, j, n, d, e, o, l, p, a, m, h, b, k, g, f, i).collect(medianAllBy(item -> item.val, Comparator.comparingInt(val -> -val))).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testMedianAllByWithoutComparator() {
+        assertEquals(asList("mm1", "mm2", "mm3"), Seq.of("lll1", "s1", "lll2", "mm1", "mm2", "lll3", "s2", "mm3", "s3", "lll4").collect(medianAllBy(String::length)).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testMedianAllByWithoutComparator2() {
+        class Item {
+            final int val;
+            Item(int val) {
+                this.val = val;
+            }
+        }
+
+        Item    a = new Item(1), b = new Item(1), c = new Item(2), d = new Item(2),
+                e = new Item(2), f = new Item(3), g = new Item(3), h = new Item(3),
+                i = new Item(4), j = new Item(4), k = new Item(5), l = new Item(6),
+                m = new Item(7), n = new Item(7), o = new Item(7), p = new Item(7);
+
+        assertEquals(asList(h, g, f), Seq.of(c, j, n, d, e, o, l, p, a, m, h, b, k, g, f, i).collect(medianAllBy(item -> item.val)).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testMedianAllWithComparator() {
+        assertEquals(asList(2, 2, 2, 2), Seq.of(1, 3, 2, 1, 2, 1, 2, 3, 3, 2).collect(medianAll(Comparator.comparingInt(o -> -o))).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testMedianAllWithComparator2() {
+        class Item implements Comparable<Item>{
+            final int val;
+            Item(int val) {
+                this.val = val;
+            }
+
+            @Override
+            public int compareTo(Item o) {
+                return this.val - o.val;
+            }
+
+            Item reverse() {
+                return new Item(-this.val);
+            }
+        }
+
+        Item    a = new Item(1), b = new Item(1), c = new Item(2), d = new Item(2),
+                e = new Item(2), f = new Item(3), g = new Item(3), h = new Item(3),
+                i = new Item(4), j = new Item(4), k = new Item(5), l = new Item(6),
+                m = new Item(7), n = new Item(7), o = new Item(7), p = new Item(7);
+
+        assertEquals(asList(j, i), Seq.of(c, j, n, d, e, o, l, p, a, m, h, b, k, g, f, i).collect(medianAll(Comparator.comparing(Item::reverse))).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testMedianAllWithoutComparator() {
+        Supplier<Seq<Integer>> s = () -> Seq.of(1, 3, 2, 1, 2, 1, 2, 3, 3, 2);
+
+        assertEquals(asList(1, 1, 1), s.get().collect(percentileAll(0.25)).toList());
+        assertEquals(asList(2, 2, 2, 2), s.get().collect(percentileAll(0.5)).toList());
+        assertEquals(asList(3, 3, 3), s.get().collect(percentileAll(0.75)).toList());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/jOOQ/jOOL/issues/221
+    @Test
+    public void testMedianAllWithoutComparator2() {
+        class Item implements Comparable<Item>{
+            final int val;
+            Item(int val) {
+                this.val = val;
+            }
+
+            @Override
+            public int compareTo(Item o) {
+                return this.val - o.val;
+            }
+
+            Item reverse() {
+                return new Item(-this.val);
+            }
+        }
+
+        Item    a = new Item(1), b = new Item(1), c = new Item(2), d = new Item(2),
+                e = new Item(2), f = new Item(3), g = new Item(3), h = new Item(3),
+                i = new Item(4), j = new Item(4), k = new Item(5), l = new Item(6),
+                m = new Item(7), n = new Item(7), o = new Item(7), p = new Item(7);
+
+        assertEquals(asList(h, g, f), Seq.of(c, j, n, d, e, o, l, p, a, m, h, b, k, g, f, i).collect(medianAll()).toList());
+    }
+
+        @Test
     public void testRank() {
 
         // Values can be obtained from PostgreSQL, e.g. with this query:


### PR DESCRIPTION
#221 

Unlike `percentileBy` and `medianBy`, the function `percentileAllBy` and `medianAllBy` will retrieve all the values of the specific percentile.

The order of the output elements is the same as the order of those elements in the input `Seq`.

I add a lot of test cases for the two functions, and all the previous and new tests are passed.

Though there is already unsubmitted commits related to issue #221  in May 2020, it seems that there were some bugs with his codes. 